### PR TITLE
Use the gotestsum test runner if present

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,9 +2,15 @@
 
 ## Prerequisites
 
+### Required
+
 * golang, version >= 1.13
 * docker, version >= 19
 * task (https://taskfile.dev/), version >= 2.6
+
+### Optional
+
+* [gotestsum](https://github.com/gotestyourself/gotestsum), for more human-friendly test output. If found in `$PATH`, it will be used in place of `go test`.
 
 ## Using Task (replacement of make)
 
@@ -52,7 +58,7 @@ envchain --set cogito COGITO_TEST_OAUTH_TOKEN
 
 ```console
 envchain --set cogito COGITO_TEST_REPO_OWNER   # Your GitHub user or organization
-envchain --set cogito COGITO_TEST_REPO_NAME
+envchain --set cogito COGITO_TEST_REPO_NAME    # The repo name (without the trailing .git)
 envchain --set cogito COGITO_TEST_COMMIT_SHA
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,9 @@ vars:
   REPO: github.com/Pix4D/cogito
   BUILD_INFO: "Tag: {{.TAG}}, commit: {{.COMMIT}}, date: {{.DATE}}"
   LDFLAGS: -w -X '{{.REPO}}/resource.buildinfo={{.BUILD_INFO}}'
+  GOTESTSUM:
+    sh: which gotestsum; true
+  TESTRUNNER: '{{if .GOTESTSUM}}{{.GOTESTSUM}}{{else}}go test{{end}}'
 
 tasks:
   default:
@@ -21,8 +24,7 @@ tasks:
   test:
     desc: Run the tests.
     cmds:
-      # `-count 1` is the idiomatic way to always run the tests (do not use the test cache)
-      - go test -count 1 ./...
+      - "{{.TESTRUNNER}} ./..."
   dotcopy:
     dir: bin
     cmds:


### PR DESCRIPTION
TODO

- [x] move merge target to master

```
    Use the gotestsum test runner if present

    Default test output:

    task test
    go test ./...
    ?       github.com/Pix4D/cogito/cmd/in  [no test files]
    ?       github.com/Pix4D/cogito/cmd/out [no test files]
    ok      github.com/Pix4D/cogito/github  0.010s
    ok      github.com/Pix4D/cogito/resource        0.017s

    With gotestsum installed (note especially that now it is evident
    if some tests are skipped):

    task test
    gotestsum ./...
    ∅  cmd/in
    ∅  cmd/out
    ✓  github (15ms)
    ✓  resource (22ms)

    === Skipped
    === SKIP: github TestGitHubStatusE2E (0.00s)
        testhelper.go:28: Skipping end-to-end test. See README for how to enable.

    === SKIP: resource TestOut (0.00s)
        testhelper.go:28: Skipping end-to-end test. See README for how to enable.

    DONE 20 tests, 2 skipped in 0.614s

    PCI-836
```