### PR TITLE
Add each member of the PCI Pix4D team as CODEOWNDERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+* @aledeganopix4d @aliculPix4D @kmdouglass @manuel-pix4d @marco-m-pix4d @muzaffar-omer @odormond @wagdav


### PR DESCRIPTION
I noticed that the CODEOWNERS file was missing and thus the team was not notified when a new PR opened.