### PR TITLE
Ensure we always return a non-null version (0.2.1 release candidate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cogito is now open source.
 - The cogito.yml sample pipeline is fully parametric.
 
+## [v0.2.1] - 2019-10-22
+
+### Fixed
+
+- Always return a non-null version also for a get step. This is unlikely to have caused any problem, but better safer than sorry.
+
 ## [v0.2.0] - 2019-10-16
 
 ### Fixed

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -153,7 +153,11 @@ func (r *Resource) In(
 	}
 
 	// Since it is not clear if it makes sense to return a "real" version for this
-	// resource, we keep it simple and return the same version we have been called with.
+	// resource, we keep it simple and return the same version we have been called with, ensuring
+	// we never return a nul version.
+	if len(version) == 0 {
+		version = dummyVersion
+	}
 	return version, oc.Metadata{}, nil
 }
 


### PR DESCRIPTION
- [ ] update release date if needed
- [ ] last tests and issue release

We were already always returning a non-nil version for the put and
check steps. This commit does the same also for the get step.

Why? Returning a nil version was crashing the ATC for a put step (see
https://github.com/concourse/concourse/pull/4442, fixed in Concourse 5.6.0).
We err on the side of caution and ensure (and explicitly tests) we do the
same also fot check and get.

It is highly unlikely that this was impacting anything since the Cogito
documentation never suggested to use a get step, but better safe than sorry.