### PR TITLE
add context namespace

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -49,8 +49,9 @@ var (
 	}
 
 	optionalSources = map[string]struct{}{
-		"log_level": struct{}{},
-		"log_url":   struct{}{},
+		"log_level":         struct{}{},
+		"log_url":           struct{}{},
+		"context_namespace": struct{}{},
 	}
 )
 
@@ -212,6 +213,10 @@ func (r *Resource) Out(
 	pipeline := env.Get("BUILD_PIPELINE_NAME")
 	job := env.Get("BUILD_JOB_NAME")
 	context := job
+	if ns, _ := source["context_namespace"].(string); ns != "" {
+		context = fmt.Sprintf("%s/%s", ns, context)
+	}
+
 	status := github.NewStatus(github.API, token, owner, repo, context)
 
 	atc := env.Get("ATC_EXTERNAL_URL")


### PR DESCRIPTION
Opening a PR for the final version of #24.

This lets a user specify a "namespace" for their contexts, allowing reuse of job-names (contexts) across multiple pipelines. 

With the resource set up like so:

```
# This is the status object that will be updated in each job
- name: gh-status
  type: cogito
  check_every: 1h
  source:
    owner: tgolsson
    repo: concourse-ci-test
    access_token: ((status-token))
    context_namespace: phatik-frontend
```

The final result with how I've configured this in my "test repo" is like this:

![image](https://user-images.githubusercontent.com/8234817/108887885-142ad000-760b-11eb-937b-f5fde04d823d.png)

I've noticed that [telia-oss/github-pr-resource](https://github.com/telia-oss/github-pr-resource) calls the same concept `base_context` which makes sense but is less clear (to me). I'm happy to change it if you'd prefer to be consistent with others.
