### PR TITLE
Allow http schema in git URL

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -350,6 +350,9 @@ func parseGitPseudoURL(URL string) (gitURL, error) {
 	} else if strings.HasPrefix(URL, "https://") {
 		gu.Scheme = "https"
 		path = URL[8:]
+	} else if strings.HasPrefix(URL, "http://") {
+		gu.Scheme = "http"
+		path = URL[7:]
 	} else {
 		return gitURL{}, fmt.Errorf("url: %v: %w", URL, errInvalidURL)
 	}


### PR DESCRIPTION
Allow http schema in git url. This allow us to use a git cache proxy in front of github which doesn't speak HTTPS.
Have a look at this for ref: https://github.com/shelmangroup/goblet/tree/github-support
