### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] [v0.4.0] - 2021-03-XX
+## [v0.4.0] - 2021-03-05
+
+### Fixed
+
+- Now the output correctly identifies the Docker tag:
+  ```
+  This is the Cogito GitHub status resource.
+  Tag: update-tooling, commit: 5dbf3c4296, build date: 2021-03-04
+  ```
 
 ### Changed
 
 - Go 1.16
 - Task > 3
 - Moved from `envchain` to `gopass` to store secrets for E2E tests (see file `CONTRIBUTING.md`).
+- Documentation enhancements.
 
-### Fixed
+### Added
 
-- Now the output correctly identifies the Docker tag:
-  ```
-  This is the Cogito GitHub status resource. Tag: update-tooling, commit: 5dbf3c4296, build date: 2021-03-04
-  ```
+- document how Cogito uses the GitHub API.
 
 ## [v0.3.0] - 2019-11-14
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,7 +65,18 @@ tasks:
       - go build -ldflags "{{.LDFLAGS}}" ../cmd/in
       - go build -ldflags "{{.LDFLAGS}}" ../cmd/out
       - go build -ldflags "{{.LDFLAGS}}" ../cmd/hello
+  docker-login:
+    silent: true
+    cmds:
+      - echo "Logging in to DockerHub"
+      - docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN 2> /dev/null
+    env:
+      DOCKER_TOKEN:
+        sh: echo ${DOCKER_TOKEN:-$(gopass show cogito/docker_token)}
+      DOCKER_USERNAME:
+        sh: echo ${DOCKER_USERNAME:-$(gopass show cogito/docker_username)}
   docker-build:
+    deps: [docker-login]
     desc: Build the Docker image.
     cmds:
       - docker build --build-arg BUILD_INFO --tag $DOCKER_IMAGE .
@@ -80,16 +91,6 @@ tasks:
       - echo
     vars:
       INPUT: '{ "source": { "owner": "foo", "repo": "bar", "access_token": "123"} }'
-  docker-login:
-    silent: true
-    cmds:
-      - echo "Logging in to DockerHub"
-      - docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN 2> /dev/null
-    env:
-      DOCKER_TOKEN:
-        sh: gopass show cogito/docker_token
-      DOCKER_USERNAME:
-        sh: gopass show cogito/docker_username
   docker-push:
     deps: [docker-login]
     cmds:
@@ -104,7 +105,7 @@ tasks:
         fi
     env:
       DOCKER_ORG:
-        sh: gopass show cogito/docker_org
+        sh: echo ${DOCKER_ORG:-$(gopass show cogito/docker_org)}
       DOCKER_TAG:
         sh: ci/git-ref-to-docker-tag.sh
       DOCKER_LATEST:


### PR DESCRIPTION
- fix: ci: docker build/push broken due to gopass and dockerhub rate limiting
- doc: CHANGELOG: release v0.4.0

Part of: PCI-1767

This release is here as a safety measure, so that we have a stable, updated point to rollback in case of need.

test pipeline: https://builder.ci.pix4d.com/teams/developers/pipelines/cogito-release-v0.4.0