### PR TITLE
add the optional put parameter `context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optional source configuration `context_prefix`, that will be prepended to the context. See [Effects on GitHub](README.md#effects-on-github) of the README.
   Thanks @tgolsson for the discussion (#24) and for the initial implementation (#25). Thanks @eitah for a similar discussion (#23).
-
+- Optional put step parameter `context`, that will override the default current job name. See [Effects on GitHub](README.md#effects-on-github) of the README.
+  Thanks @eitah for the discussion (#23).
 
 ## [v0.4.0] - 2021-03-05
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ With reference to the [GitHub status API], the `POST` parameters (`state`, `targ
 
 ## Optional
 
-- `context_prefix`: The prefix for the context (see section [Effects on GitHub](#effects-on-github)). If present, the context will be `context_prefix/job_name` Default: empty (that is, the context will be: `job_name`).
+- `context_prefix`: The prefix for the context (see section [Effects on GitHub](#effects-on-github)). If present, the context will be `context_prefix/job_name`. Default: empty. See also the optional `context` in the [put step](#the-put-step).
 - `log_level`: The log level (one of `debug`, `info`, `warn`, `error`, `silent`). Default: `info`.
 - `log_url`. A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < 7.
 
@@ -133,11 +133,13 @@ It is currently a no-op.
 
 Sets or updates the GitHub status for a given commit, following the [GitHub status API].
 
-## Parameters
+## Required
 
-### Required
+- `state`: The state to set. One of `error`, `failure`, `pending`, `success`.
 
-- `state`: The state to be set. One of `error`, `failure`, `pending`, `success`.
+## Optional:
+
+- `context`: The value of the non-prefix part of the context (see section [Effects on GitHub](#effects-on-github)). Default: `job_name`. See also the optional `context_prefix` in the [source configuration](#source-configuration).
 
 ## Note
 

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -184,6 +184,24 @@ func TestOut(t *testing.T) {
 				nil,
 			},
 		},
+		{"put step: default context",
+			in{defSource, defParams, defEnv},
+			want{
+				defVersion,
+				defMeta,
+				map[string]string{"context": defEnv.Get("BUILD_JOB_NAME")},
+				nil,
+			},
+		},
+		{"put step: optional: context",
+			in{defSource, oc.Params{"state": "error", "context": "bello"}, defEnv},
+			want{
+				defVersion,
+				defMeta,
+				map[string]string{"context": "bello"},
+				nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
add the optional put parameter `context`, that will override the default current job name.

See the README for more information.

Closes #23