### PR TITLE
Pci 1937 better error msg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,9 @@ We require environment variables (as opposed to using a configuration file) to p
 * To enable any contributor to run their own tests without having to edit any file.
 * To securely store secrets!
 
-## Default test repositories
+## Default test repository
 
 * https://github.com/Pix4D/cogito-test-read-write
-* https://github.com/Pix4D/cogito-test-read-only
 
 ## Secure handling of the GitHub OAuth token
 
@@ -138,19 +137,9 @@ cogito/
 ├── docker_username
 ├── test_commit_sha
 ├── test_oauth_token
-├── test_read_only_commit_sha
-├── test_read_only_repo_name
 ├── test_repo_name
 └── test_repo_owner
 ```
-
-## Read-only repository tests
-
-There are some failure modes that are testable only with a repository for which the user that issues the OAuth token has read-only access to it.
-
-Any public repository of a organization to which the user doesn't belong to satisfies this requirement.
-
-In the tests, we use one of the repositories belonging to `octocat`.
 
 ## Running the end-to-end tests
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,10 +45,6 @@ tasks:
         sh: gopass show cogito/test_commit_sha
       COGITO_TEST_OAUTH_TOKEN:
         sh: gopass show cogito/test_oauth_token
-      COGITO_TEST_READ_ONLY_COMMIT_SHA:
-        sh: gopass show cogito/test_read_only_commit_sha
-      COGITO_TEST_READ_ONLY_REPO_NAME:
-        sh: gopass show cogito/test_read_only_repo_name
       COGITO_TEST_REPO_NAME:
         sh: gopass show cogito/test_repo_name
       COGITO_TEST_REPO_OWNER:

--- a/github/status_test.go
+++ b/github/status_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -50,44 +49,6 @@ func TestGitHubStatusE2E(t *testing.T) {
 	}
 }
 
-func TestGitHubStatusCanDiagnoseReadOnlyUser(t *testing.T) {
-	cfg := help.SkipTestIfNoEnvVars(t)
-	const readOnlyOwner = "octocat"
-	const readOnlyRepo = "Spoon-Knife"
-	const readOnlySHA = "d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9"
-	const context = "dummy"
-	const targetURL = "dummy"
-	desc := time.Now().Format("15:04:05")
-	const state = "success"
-
-	status := github.NewStatus(github.API, cfg.Token, readOnlyOwner, readOnlyRepo, context)
-
-	if err := status.CanReadRepo(); err != nil {
-		t.Fatalf("\ngot:  %v\nwant: no error", err)
-	}
-
-	err := status.Add(readOnlySHA, state, targetURL, desc)
-
-	var statusErr *github.StatusError
-	wantStatusCode := http.StatusNotFound
-	if errors.As(err, &statusErr) {
-		if statusErr.StatusCode != wantStatusCode {
-			t.Fatalf("\ngot:  %v %v\nwant: %v %v\ndetails: %v",
-				statusErr.StatusCode, http.StatusText(statusErr.StatusCode),
-				wantStatusCode, http.StatusText(wantStatusCode),
-				err)
-		}
-		// As ugly as it is, I have to read into the error message :-(
-		const wantDiagnose = "The user with this token doesn't have write access to the repo"
-		if !strings.Contains(statusErr.Error(), wantDiagnose) {
-			t.Fatalf("Error message (%v) does not contain expected diagnosis (%v)",
-				statusErr.Error(), wantDiagnose)
-		}
-	} else {
-		t.Fatalf("got %v; want *github.StatusError", reflect.TypeOf(err))
-	}
-}
-
 func TestUnderstandGitHubStatusFailures(t *testing.T) {
 	cfg := help.SkipTestIfNoEnvVars(t)
 
@@ -125,50 +86,6 @@ func TestUnderstandGitHubStatusFailures(t *testing.T) {
 				}
 			} else {
 				t.Fatalf("got %v; want *github.StatusError", reflect.TypeOf(err))
-			}
-		})
-	}
-}
-
-func TestStatusValidate(t *testing.T) {
-	cfg := help.SkipTestIfNoEnvVars(t)
-
-	var testCases = []struct {
-		name       string
-		token      string
-		owner      string
-		repo       string
-		wantStatus int
-	}{
-		{"bad token -> Unauthorized",
-			"bad-token", cfg.Owner, cfg.Repo, http.StatusUnauthorized},
-		{"non existing repo -> Not Found",
-			cfg.Token, cfg.Owner, "non-existing-really", http.StatusNotFound},
-	}
-
-	t.Run("happy path", func(t *testing.T) {
-		status := github.NewStatus(github.API, cfg.Token, cfg.Owner, cfg.Repo, "dummy")
-
-		if err := status.CanReadRepo(); err != nil {
-			t.Fatalf("got: %v; want: no error", err)
-		}
-	})
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			status := github.NewStatus(github.API, tc.token, tc.owner, tc.repo, "dummy")
-
-			err := status.CanReadRepo()
-
-			var statusErr *github.StatusError
-			if errors.As(err, &statusErr) {
-				if statusErr.StatusCode != tc.wantStatus {
-					t.Fatalf("status code: got %v (%v); want %v (%v)\nerror: %v",
-						statusErr.StatusCode, http.StatusText(statusErr.StatusCode),
-						tc.wantStatus, http.StatusText(tc.wantStatus), err)
-				}
-			} else {
-				t.Fatalf("got %v; want github.StatusError", reflect.TypeOf(err))
 			}
 		})
 	}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -335,7 +335,7 @@ func repodirMatches(dir, owner, repo string) error {
 	right := []string{gu.Host, gu.Owner, gu.Repo}
 	for i, l := range left {
 		r := right[i]
-		if strings.ToLower(l) != strings.ToLower(r) {
+		if !strings.EqualFold(l, r) {
 			return fmt.Errorf("remote: %v: got: %q; want: %q: %w", remote, r, l, errWrongRemote)
 		}
 	}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -336,7 +336,9 @@ func repodirMatches(dir, owner, repo string) error {
 	for i, l := range left {
 		r := right[i]
 		if !strings.EqualFold(l, r) {
-			return fmt.Errorf("remote: %v: got: %q; want: %q: %w", remote, r, l, errWrongRemote)
+			return fmt.Errorf("resource source configuration and git repository are incompatible.\nGit remote: %q\n"+
+				"Resource config: host: github.com, owner: %q, repo: %q. %w", remote, owner, repo, errWrongRemote,
+			)
 		}
 	}
 	return nil

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -348,7 +348,7 @@ func TestRepoDirMatches(t *testing.T) {
 		{"dir is not a repo", "not-a-repo", "dummyurl", os.ErrNotExist},
 		{"bad .git/config", "repo-bad-git-config", "dummyurl", errKeyNotFound},
 		{"repo with wrong HTTPS remote", "a-repo", httpsRemote("owner", "repo"), errWrongRemote},
-		{"repo with wrong SSH remote", "a-repo", sshRemote("owner", "repo"), errWrongRemote},
+		{"repo with wrong SSH remote or wrong source config", "a-repo", sshRemote("owner", "repo"), errWrongRemote},
 		{"repo with good SSH remote", "a-repo", sshRemote(wantOwner, wantRepo), nil},
 		{"repo with good HTTPS remote", "a-repo", httpsRemote(wantOwner, wantRepo), nil},
 	}


### PR DESCRIPTION
CODE before this PR:
```
  left := []string{"github.com", owner, repo} 
  right := []string{gu.Host, gu.Owner, gu.Repo}
  for i, l := range left {
    r := right[i]
    if strings.ToLower(l) != strings.ToLower(r) {
      return fmt.Errorf("remote: %v: got: %q; want: %q: %w", remote, r, l, errWrongRemote)
    }
  }
```

- left is a given configuration set under source configuration
- right is the data parsed from `.git/config`
- error is raised if they don't match

By looking at the error in the ticket
`remote: git@github.com:pix4d/fly_helper.git: got: "fly_helper"; want: "fly_helper.git": wrong git remote`
We can identify the following:
- remote is the value parsed from the `.git/config`, while string `"fly_helper"` just after the got is obtained by parsing the remote string.
- on the other hand string `"fly_helper.git"` arrives from the cogito resource source configuration, which means that `"fly_helper.git"` is the wrong value.
- if we continue from here the http request will fail because `https://github.com/pix4d/fly_helper.git` does not exists while `https://github.com/pix4d/fly_helper` does
- this points us that we put the wrong value in our pipeline resource configuration. 

```
WRONG:
  - name: gh-status
    type: cogito
    check_every: 24h
    source:
      owner: pix4d
      repo: fly_helper.git
      access_token: ((github_repo_status_token))

```
Correct behavior is to stop the code execution here, which is exactly the current behavior. But we should print a better error message i.e like: "cogito source: you have set the wrong repo name"

I additionally added two boy-scout commits. They are a part of this PR because otherwise I could not run the e2e tests.
Note that: https://github.com/Pix4D/cogito-test-read-only do not exist.
