### PR TITLE
PCI-1937 Improve error message when token does not have write access to the repo.

### DIFF
--- a/github/status_test.go
+++ b/github/status_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -50,44 +49,6 @@ func TestGitHubStatusE2E(t *testing.T) {
 	}
 }
 
-func TestGitHubStatusCanDiagnoseReadOnlyUser(t *testing.T) {
-	cfg := help.SkipTestIfNoEnvVars(t)
-	const readOnlyOwner = "octocat"
-	const readOnlyRepo = "Spoon-Knife"
-	const readOnlySHA = "d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9"
-	const context = "dummy"
-	const targetURL = "dummy"
-	desc := time.Now().Format("15:04:05")
-	const state = "success"
-
-	status := github.NewStatus(github.API, cfg.Token, readOnlyOwner, readOnlyRepo, context)
-
-	if err := status.CanReadRepo(); err != nil {
-		t.Fatalf("\ngot:  %v\nwant: no error", err)
-	}
-
-	err := status.Add(readOnlySHA, state, targetURL, desc)
-
-	var statusErr *github.StatusError
-	wantStatusCode := http.StatusNotFound
-	if errors.As(err, &statusErr) {
-		if statusErr.StatusCode != wantStatusCode {
-			t.Fatalf("\ngot:  %v %v\nwant: %v %v\ndetails: %v",
-				statusErr.StatusCode, http.StatusText(statusErr.StatusCode),
-				wantStatusCode, http.StatusText(wantStatusCode),
-				err)
-		}
-		// As ugly as it is, I have to read into the error message :-(
-		const wantDiagnose = "The user with this token doesn't have write access to the repo"
-		if !strings.Contains(statusErr.Error(), wantDiagnose) {
-			t.Fatalf("Error message (%v) does not contain expected diagnosis (%v)",
-				statusErr.Error(), wantDiagnose)
-		}
-	} else {
-		t.Fatalf("got %v; want *github.StatusError", reflect.TypeOf(err))
-	}
-}
-
 func TestUnderstandGitHubStatusFailures(t *testing.T) {
 	cfg := help.SkipTestIfNoEnvVars(t)
 
@@ -125,50 +86,6 @@ func TestUnderstandGitHubStatusFailures(t *testing.T) {
 				}
 			} else {
 				t.Fatalf("got %v; want *github.StatusError", reflect.TypeOf(err))
-			}
-		})
-	}
-}
-
-func TestStatusValidate(t *testing.T) {
-	cfg := help.SkipTestIfNoEnvVars(t)
-
-	var testCases = []struct {
-		name       string
-		token      string
-		owner      string
-		repo       string
-		wantStatus int
-	}{
-		{"bad token -> Unauthorized",
-			"bad-token", cfg.Owner, cfg.Repo, http.StatusUnauthorized},
-		{"non existing repo -> Not Found",
-			cfg.Token, cfg.Owner, "non-existing-really", http.StatusNotFound},
-	}
-
-	t.Run("happy path", func(t *testing.T) {
-		status := github.NewStatus(github.API, cfg.Token, cfg.Owner, cfg.Repo, "dummy")
-
-		if err := status.CanReadRepo(); err != nil {
-			t.Fatalf("got: %v; want: no error", err)
-		}
-	})
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			status := github.NewStatus(github.API, tc.token, tc.owner, tc.repo, "dummy")
-
-			err := status.CanReadRepo()
-
-			var statusErr *github.StatusError
-			if errors.As(err, &statusErr) {
-				if statusErr.StatusCode != tc.wantStatus {
-					t.Fatalf("status code: got %v (%v); want %v (%v)\nerror: %v",
-						statusErr.StatusCode, http.StatusText(statusErr.StatusCode),
-						tc.wantStatus, http.StatusText(tc.wantStatus), err)
-				}
-			} else {
-				t.Fatalf("got %v; want github.StatusError", reflect.TypeOf(err))
 			}
 		})
 	}


### PR DESCRIPTION
- Improve error message when token does not have write access to the repo.

Note:
Github will return `404` error if:
- if repo does not exists
- if user has token with correct scope but no access to the repository i.e `pix4d-service-account-cloud`
- if user has token with wrong scope but no access to the repository i.e `pix4d-service-account-cloud`
- if user has wrong token scope but has at least read access to the repo i.e current situation with `Pix4D-Janus`. 

To actually get a `200` status code in `CanReadRepo()` function when doing `API: GET /repos/:owner/:repo` http request we MUST extend the scope for the token from `repo:status` to `repo`. We don't want to do that. 

Additionally, if we actually reached line 137 we are almost 100% sure that the repo exists. Of course there is a small possibility that someone deleted the repo between Concourse fetched it and we reach this point in the code.