### PR TITLE
CI: move to GitHub Actions, part 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,12 @@ jobs:
           # as we don't need it.
           persist-credentials: false
       - run: task ci:setup
-      # # fixme - run: task lint
+      # fixme - run: task lint
       - run: task build
-      - run: task test
+      - run: task test:unit
+      - run: task test:integration
+        env:
+          COGITO_TEST_OAUTH_TOKEN: ${{ secrets.COGITO_TEST_OAUTH_TOKEN }}
       - run: task docker:build
       - run: task docker:smoke
       - run: task docker:login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+# See https://docs.github.com/en/actions/reference/
+
+# on:
+#   release:
+#     # Only use the types keyword to narrow down the activity types that will trigger
+#     # your workflow.
+#     types: [published, created, edited]
+#
+# on:
+#   pull_request:
+    # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+    # On event pull_request, the workflow runs only on activity types opened,
+    # synchronize, or reopened. Change this default with the types keyword.
+    #types: [opened, synchronize, reopened]
+
+on: [push]
+
+name: ci
+
+env:
+  go-version: 1.16.x
+  task-version: v3.7.3
+  DOCKER_ORG: pix4d
+
+jobs:
+  all:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.go-version }}
+      - name: Install Task
+        run: go install github.com/go-task/task/v3/cmd/task@${{ env.task-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # By default, actions/checkout will persist the GITHUB_TOKEN, so that further
+          # steps in the job can perform authenticated git commands (that is: WRITE to
+          # the repo). Following the Principle of least privilege, we disable this as long
+          # as we don't need it.
+          persist-credentials: false
+      - run: task ci:setup
+      # # fixme - run: task lint
+      - run: task build
+      - run: task test
+      - run: task docker:build
+      - run: task docker:smoke
+      - run: task docker:login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      - run: task docker:push
+      - run: task ci:teardown
+        # ALWAYS run this step, also if any previous step failed.
+        if: always()
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED - 2021-09-xx
+
+### Changed
+
+- CI: move from Travis to GitHub Actions.
+- tests: new Task targets `test:unit` (replaces target `test`) and `test:integration` (replaces target `test-integration`).
+- build: cleaner Taskfile.
+
 ## [v0.6.0] - 2021-08-26
 
 ### Added

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,9 +10,7 @@ vars:
   REPO: github.com/Pix4D/cogito
   DOCKER_TAG:
     sh: ci/git-ref-to-docker-tag.sh
-  DOCKER_ORG:
-    sh: if [ -n "$DOCKER_ORG" ]; then echo "$DOCKER_ORG";
-      else echo $(gopass show cogito/docker_org); fi
+  DOCKER_ORG: '{{default "pix4d" .DOCKER_ORG}}'
   DOCKER_IMAGE: cogito
   DOCKER_BASE_NAME: "{{.DOCKER_ORG}}/{{.DOCKER_IMAGE}}"
   DOCKER_FULL_NAME: "{{.DOCKER_BASE_NAME}}:{{.DOCKER_TAG}}"
@@ -26,6 +24,7 @@ vars:
   GOTESTSUM_VERSION: v1.7.0
 
 tasks:
+
   install:deps:
     desc: Install tool dependencies.
     cmds:
@@ -33,34 +32,31 @@ tasks:
       - go install gotest.tools/gotestsum@{{.GOTESTSUM_VERSION}}
 
   lint:
-    desc: Lint the code
+    desc: Lint the code.
     cmds:
       # The flag "--enable" actually _adds_ to the default linters
       - golangci-lint run --enable gofmt,gocritic ./...
 
-  test:
+  test:unit:
     desc: Run the unit tests.
     cmds:
-      - "{{.TESTRUNNER}} -count=1 -coverprofile=coverage.out ./..."
+      - "{{.TESTRUNNER}} -count=1 -short -coverprofile=coverage.out ./..."
 
   test:env:
     desc: "Run what is passed on the command-line with a shell environment containing the secrets needed for the integration tests. Example: task test:env -- go test -count=1 -run '^TestFooIntegration' ./pkg/update"
     cmds:
       - '{{ .CLI_ARGS }}'
     env: &test-env
-      COGITO_TEST_COMMIT_SHA:
-        sh: gopass show cogito/test_commit_sha
+      COGITO_TEST_COMMIT_SHA: '{{default "32e4b4f91bb8de500f6a7aa2011f93c3f322381c" .COGITO_TEST_COMMIT_SHA}}'
       COGITO_TEST_OAUTH_TOKEN:
-        sh: gopass show cogito/test_oauth_token
-      COGITO_TEST_REPO_NAME:
-        sh: gopass show cogito/test_repo_name
-      COGITO_TEST_REPO_OWNER:
-        sh: gopass show cogito/test_repo_owner
+        sh: 'echo {{default "$(gopass show cogito/test_oauth_token)" .COGITO_TEST_OAUTH_TOKEN}}'
+      COGITO_TEST_REPO_NAME: '{{default "cogito-test-read-write" .COGITO_TEST_REPO_NAME}}'
+      COGITO_TEST_REPO_OWNER: '{{default "pix4d" .COGITO_TEST_REPO_OWNER}}'
 
   test:integration:
-    desc: Run also the integration tests.
+    desc: Run the integration tests.
     cmds:
-      - "{{.TESTRUNNER}} -count=1 -coverprofile=coverage.out ./..."
+      - "{{.TESTRUNNER}} -count=1 -run 'Test.*Integration$' -coverprofile=coverage.out ./..."
     env: *test-env
 
   build:
@@ -83,11 +79,9 @@ tasks:
       - echo $DOCKER_TOKEN | docker login -u $DOCKER_USERNAME --password-stdin
     env:
       DOCKER_USERNAME:
-        sh: if [ -n "$DOCKER_USERNAME" ]; then echo "$DOCKER_USERNAME";
-            else echo $(gopass show cogito/docker_username); fi
+        sh: 'echo {{default "$(gopass show cogito/docker_username)" .DOCKER_USERNAME}}'
       DOCKER_TOKEN:
-        sh: if [ -n "$DOCKER_TOKEN" ]; then echo "$DOCKER_TOKEN";
-            else echo $(gopass show cogito/docker_token); fi
+        sh: 'echo {{default "$(gopass show cogito/docker_token)" .DOCKER_TOKEN}}'
 
   docker:build:
     desc: Build the Docker image.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,40 +3,45 @@
 
 version: "3"
 
-env:
-  DOCKER_IMAGE: cogito
-
 vars:
   DATE: '{{ now | date "2006-01-02" }}'
   COMMIT:
     sh: git log -n 1 --format=%h
   REPO: github.com/Pix4D/cogito
-  TAG:
+  DOCKER_TAG:
     sh: ci/git-ref-to-docker-tag.sh
-  BUILD_INFO: "Tag: {{.TAG}}, commit: {{.COMMIT}}, build date: {{.DATE}}"
+  DOCKER_ORG:
+    sh: if [ -n "$DOCKER_ORG" ]; then echo "$DOCKER_ORG";
+      else echo $(gopass show cogito/docker_org); fi
+  DOCKER_IMAGE: cogito
+  DOCKER_BASE_NAME: "{{.DOCKER_ORG}}/{{.DOCKER_IMAGE}}"
+  DOCKER_FULL_NAME: "{{.DOCKER_BASE_NAME}}:{{.DOCKER_TAG}}"
+  BUILD_INFO: "Tag: {{.DOCKER_TAG}}, commit: {{.COMMIT}}, build date: {{.DATE}}"
   LDFLAGS: -w -X '{{.REPO}}/resource.buildinfo={{.BUILD_INFO}}'
   GOTESTSUM:
     sh: "echo $(which gotestsum 2> /dev/null)"
   TESTRUNNER: "{{if .GOTESTSUM}}{{base .GOTESTSUM}} --{{else}}go test{{end}}"
+  #
+  GOLANGCI_VERSION: v1.42.1
+  GOTESTSUM_VERSION: v1.7.0
 
 tasks:
-  default:
-    deps: [test]
-    desc: Sensible defaults if you invoke `task` without arguments.
-
-  ci-init:
-    desc: Useful only when running under CI.
+  install:deps:
+    desc: Install tool dependencies.
     cmds:
-      - cmd: go get gotest.tools/gotestsum
-      - cmd: echo
-        silent: true
-      - cmd: go mod download
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@{{.GOLANGCI_VERSION}}
+      - go install gotest.tools/gotestsum@{{.GOTESTSUM_VERSION}}
+
+  lint:
+    desc: Lint the code
+    cmds:
+      # The flag "--enable" actually _adds_ to the default linters
+      - golangci-lint run --enable gofmt,gocritic ./...
 
   test:
     desc: Run the unit tests.
     cmds:
       - "{{.TESTRUNNER}} -count=1 -coverprofile=coverage.out ./..."
-      - go tool cover -html=coverage.out -o coverage.html
 
   test:env:
     desc: "Run what is passed on the command-line with a shell environment containing the secrets needed for the integration tests. Example: task test:env -- go test -count=1 -run '^TestFooIntegration' ./pkg/update"
@@ -52,21 +57,13 @@ tasks:
       COGITO_TEST_REPO_OWNER:
         sh: gopass show cogito/test_repo_owner
 
-  test-integration:
+  test:integration:
     desc: Run also the integration tests.
     cmds:
       - "{{.TESTRUNNER}} -count=1 -coverprofile=coverage.out ./..."
-      - go tool cover -html=coverage.out -o coverage.html
     env: *test-env
 
-  copydir:
-    desc: Build copydir.
-    dir: bin
-    cmds:
-      - go build -ldflags "{{.LDFLAGS}}" ../cmd/copydir
-
   build:
-    deps: [copydir]
     desc: Build on the local machine.
     dir: bin
     cmds:
@@ -75,51 +72,73 @@ tasks:
       - go build -ldflags "{{.LDFLAGS}}" ../cmd/out
       - go build -ldflags "{{.LDFLAGS}}" ../cmd/hello
 
-  docker-login:
-    silent: true
+  build:copydir:
+    desc: Build copydir (development helper, normally not needed).
+    dir: bin
     cmds:
-      - echo "Logging in to DockerHub"
-      - docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN 2> /dev/null
-    env:
-      DOCKER_TOKEN:
-        sh: echo ${DOCKER_TOKEN:-$(gopass show cogito/docker_token)}
-      DOCKER_USERNAME:
-        sh: echo ${DOCKER_USERNAME:-$(gopass show cogito/docker_username)}
+      - go build -ldflags "{{.LDFLAGS}}" ../cmd/copydir
 
-  docker-build:
-    deps: [docker-login]
+  docker:login:
+    cmds:
+      - echo $DOCKER_TOKEN | docker login -u $DOCKER_USERNAME --password-stdin
+    env:
+      DOCKER_USERNAME:
+        sh: if [ -n "$DOCKER_USERNAME" ]; then echo "$DOCKER_USERNAME";
+            else echo $(gopass show cogito/docker_username); fi
+      DOCKER_TOKEN:
+        sh: if [ -n "$DOCKER_TOKEN" ]; then echo "$DOCKER_TOKEN";
+            else echo $(gopass show cogito/docker_token); fi
+
+  docker:build:
     desc: Build the Docker image.
     cmds:
-      - docker build --build-arg BUILD_INFO --tag $DOCKER_IMAGE .
+      - docker build --build-arg BUILD_INFO --tag {{.DOCKER_FULL_NAME}} .
     env:
       BUILD_INFO: "{{.BUILD_INFO}}"
 
-  docker-smoke:
+  docker:smoke:
     desc: Simple smoke test of the Docker image.
     cmds:
-      - echo '{{.INPUT}}' | docker run --rm --interactive cogito /opt/resource/check
+      - echo '{{.INPUT}}' | docker run --rm --interactive {{.DOCKER_FULL_NAME}} /opt/resource/check
       - echo
-      - echo '{{.INPUT}}' | docker run --rm --interactive cogito /opt/resource/in dummy
+      - echo '{{.INPUT}}' | docker run --rm --interactive {{.DOCKER_FULL_NAME}} /opt/resource/in dummy
       - echo
     vars:
       INPUT: '{ "source": { "owner": "foo", "repo": "bar", "access_token": "123"} }'
 
-  docker-push:
-    deps: [docker-login]
+  docker:push:
+    desc: Push the Docker image
     cmds:
-      - docker tag $DOCKER_IMAGE $DOCKER_ORG/$DOCKER_IMAGE:$DOCKER_TAG
-      - echo Pushing $DOCKER_ORG/$DOCKER_IMAGE:$DOCKER_TAG
-      - docker push $DOCKER_ORG/$DOCKER_IMAGE:$DOCKER_TAG
+      - docker push {{.DOCKER_FULL_NAME}}
       - |-
         if [ -n "$DOCKER_LATEST" ]; then
-            docker tag $DOCKER_IMAGE $DOCKER_ORG/$DOCKER_IMAGE:$DOCKER_LATEST
-            echo Pushing $DOCKER_ORG/$DOCKER_IMAGE:$DOCKER_LATEST
-            docker push $DOCKER_ORG/$DOCKER_IMAGE:$DOCKER_LATEST
+            docker tag {{.DOCKER_FULL_NAME}} {{.DOCKER_BASE_NAME}}:latest
+            # FIXME safety while adding GH actions: disable pushing "latest"
+            exit 1
+            docker push {{.DOCKER_BASE_NAME}}:latest
+            echo Pushed a new \"latest\" tag!
+        else
+            echo Did not push a new \"latest\" tag.
         fi
-    env:
-      DOCKER_ORG:
-        sh: echo ${DOCKER_ORG:-$(gopass show cogito/docker_org)}
-      DOCKER_TAG:
-        sh: ci/git-ref-to-docker-tag.sh
+    vars:
       DOCKER_LATEST:
         sh: ci/git-latest.sh
+
+  ci:setup:
+    desc: Useful only when running under CI.
+    cmds:
+      - task: install:deps
+      # Running "go mod download" is optional, since "go build" would do it anyway.
+      # We run it explicitly to make the output of "go build" more focused.
+      - cmd: go mod download -x
+
+  # When using GitHub Actions, add this snippet at the end of the workflow:
+  #    - run: docker logout
+  #    # Always remove credentials, also if any previous step failed.
+  #    if: always()
+  ci:teardown:
+    desc: ALWAYS run this when in CI (reduces security exposures)
+    cmds:
+      # Remove credentials from the file system, added by "docker login" :-(
+      - cmd: docker logout
+

--- a/cmd/copydir/main.go
+++ b/cmd/copydir/main.go
@@ -1,3 +1,4 @@
+// Useful when developing help.CopyDir.
 package main
 
 import (

--- a/github/status_test.go
+++ b/github/status_test.go
@@ -34,7 +34,10 @@ func TestGitHubStatusUseMockAPI(t *testing.T) {
 	}
 }
 
-func TestGitHubStatusE2E(t *testing.T) {
+func TestGitHubStatusIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	cfg := help.SkipTestIfNoEnvVars(t)
 	context := "cogito/test"
 	targetURL := "https://cogito.invalid/builds/job/42"
@@ -49,7 +52,10 @@ func TestGitHubStatusE2E(t *testing.T) {
 	}
 }
 
-func TestUnderstandGitHubStatusFailures(t *testing.T) {
+func TestUnderstandGitHubStatusFailuresIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	cfg := help.SkipTestIfNoEnvVars(t)
 
 	var testCases = []struct {

--- a/help/testhelper.go
+++ b/help/testhelper.go
@@ -158,6 +158,8 @@ var FakeTestCfg = TestCfg{
 // Requiring the testing.T parameter is done on purpose to combat the temptation to use this
 // function in production :-)
 func SkipTestIfNoEnvVars(t *testing.T) TestCfg {
+	t.Helper()
+
 	token := os.Getenv("COGITO_TEST_OAUTH_TOKEN")
 	owner := os.Getenv("COGITO_TEST_REPO_OWNER")
 	repo := os.Getenv("COGITO_TEST_REPO_NAME")
@@ -165,11 +167,11 @@ func SkipTestIfNoEnvVars(t *testing.T) TestCfg {
 
 	// If none of the environment variables are set, we skip the test.
 	if len(token) == 0 && len(owner) == 0 && len(repo) == 0 && len(SHA) == 0 {
-		t.Skip("Skipping end-to-end test. See CONTRIBUTING for how to enable.")
+		t.Skip("Skipping integration test. See CONTRIBUTING for how to enable.")
 	}
 	// If some of the environment variables are set and some not, we fail the test.
 	if len(token) == 0 || len(owner) == 0 || len(repo) == 0 || len(SHA) == 0 {
-		t.Fatal("Some end-to-end env vars are set and some not. See CONTRIBUTING for how to fix.")
+		t.Fatal("Some integration env vars are set and some not. See CONTRIBUTING for how to fix.")
 	}
 
 	return TestCfg{token, owner, repo, SHA}

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -255,7 +255,10 @@ func TestOut(t *testing.T) {
 	}
 }
 
-func TestOutE2E(t *testing.T) {
+func TestOutIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	cfg := help.SkipTestIfNoEnvVars(t)
 
 	defSource := oc.Source{"access_token": cfg.Token, "owner": cfg.Owner, "repo": cfg.Repo}


### PR DESCRIPTION
Best reviewed commit-per-commit.

- build: cleanup Taskfile and prepare for GitHub Actions
- ci: basic GitHub Action
    - build and unit tests on host (not Docker)
    - build and publish a Docker image (no release yet, per-feature branch)
    - OOB this PR but needed: Docker credentials added as GitHub repository secret, see https://docs.github.com/en/actions/reference/encrypted-secrets
- doc: update CHANGELOG
-    ci: run integration tests
    - run integration tests
    - add COGITO_TEST_OAUTH_TOKEN to GitHub repo secrets
    - found a nice way to simplify reading environment variables in Taskfile

PCI-2030
