### PR TITLE
Pci 2079 extends handle server errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ With reference to the [GitHub status API], the `POST` parameters (`state`, `targ
 
 - `owner`: The GitHub user or organization.
 - `repo`: The GitHub repository name.
-- `access-token`: The OAuth access token. See section [GitHub OAuth token](#github-oauth-token).
+- `access_token`: The OAuth access token. See section [GitHub OAuth token](#github-oauth-token).
 
 ## Optional
 

--- a/github/status.go
+++ b/github/status.go
@@ -140,7 +140,9 @@ func (s status) Add(sha, state, targetURL, description string) error {
 				"\t2. The user who issued the token doesn't have write access to the repo\n"+
 				"\t3. The token doesn't have scope repo:status\n", path.Join(s.owner, s.repo),
 		)
-		return &StatusError{req.Method + " " + url + msg + OAuthInfo, resp.StatusCode, string(respBody)}
+		return &StatusError{req.Method + " " + url + msg + OAuthInfo, resp.StatusCode, fmt.Sprintf("%s\n%s", http.StatusText(resp.StatusCode), string(respBody))}
+	case http.StatusInternalServerError:
+		return &StatusError{req.Method + " " + url + OAuthInfo, resp.StatusCode, fmt.Sprintf("%s\nMay be %s is not healthy?", http.StatusText(resp.StatusCode), s.server)}
 	default:
 		// Any other error
 		return &StatusError{req.Method + " " + url + OAuthInfo, resp.StatusCode, string(respBody)}


### PR DESCRIPTION
We felt on a case where the server services were not healthy  and it was not evident at a glance to the end user. This PR aims to improve the handling of http error 500.

In order to achieve this clarity, one more `case` is added to check this specific http exit code before to evaluate `default`. Today, in case of server issues, only the error code (500) and an empty response body is returned. With this PR the message reports the error code, the  corresponding text and the FQDN of the server.

### Tests
The test part is enlarged to cover `http` 404 and 500.

#### Unit
✓  github (7ms) (coverage: 85.7% of statements)
✓  resource (31ms) (coverage: 91.4% of statements)
DONE 53 tests, 3 skipped in 0.397s

#### Integration
✓  resource (361ms) (coverage: 66.7% of statements)
✓  github (1.223s) (coverage: 82.1% of statements)
DONE 10 tests in 1.581s


