### PR TITLE
cosmetic: reformat code base to max line lenght 99

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ cogito/
 We are finally ready to run also the integration tests:
 
 ```
-$ task test-integration
+$ task test:integration
 ```
 
 The integration tests have the following logic:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,8 +22,9 @@ vars:
     sh: "echo $(which gotestsum 2> /dev/null)"
   TESTRUNNER: "{{if .GOTESTSUM}}{{base .GOTESTSUM}} --{{else}}go test{{end}}"
   #
-  GOLANGCI_VERSION: v1.42.1
+  GOLANGCI_VERSION: v1.43.0
   GOTESTSUM_VERSION: v1.7.0
+  GOLINES_VERSION: v0.7.0
 
 tasks:
 
@@ -32,11 +33,17 @@ tasks:
     cmds:
       - go install github.com/golangci/golangci-lint/cmd/golangci-lint@{{.GOLANGCI_VERSION}}
       - go install gotest.tools/gotestsum@{{.GOTESTSUM_VERSION}}
+      - go install github.com/segmentio/golines@{{.GOLINES_VERSION}}
 
   lint:
     desc: Lint the code.
     cmds:
       - golangci-lint run ./...
+
+  lint:linelength:
+    desc: Enforce max line length. Use the tool output only as a hint, sometimes it makes wrong decisions.
+    cmds:
+      - golines --max-len=99 --write-output .
 
   test:unit:
     desc: Run the unit tests.

--- a/github/status.go
+++ b/github/status.go
@@ -134,17 +134,31 @@ func (s status) Add(sha, state, targetURL, description string) error {
 		// Happy path
 		return nil
 	case http.StatusNotFound:
-		msg := fmt.Sprintf(
-			"\nOne of the following happened:\n"+
-				"\t1. The repo https://github.com/%s doesn't exist\n"+
-				"\t2. The user who issued the token doesn't have write access to the repo\n"+
-				"\t3. The token doesn't have scope repo:status\n", path.Join(s.owner, s.repo),
-		)
-		return &StatusError{req.Method + " " + url + msg + OAuthInfo, resp.StatusCode, fmt.Sprintf("%s\n%s", http.StatusText(resp.StatusCode), string(respBody))}
+		msg := fmt.Sprintf(`
+One of the following happened:
+    1. The repo https://github.com/%s doesn't exist
+	2. The user who issued the token doesn't have write access to the repo
+	3. The token doesn't have scope repo:status
+`,
+			path.Join(s.owner, s.repo))
+		return &StatusError{
+			req.Method + " " + url + msg + OAuthInfo,
+			resp.StatusCode,
+			fmt.Sprintf("%s\n%s", http.StatusText(resp.StatusCode), string(respBody)),
+		}
 	case http.StatusInternalServerError:
-		return &StatusError{req.Method + " " + url + OAuthInfo, resp.StatusCode, fmt.Sprintf("%s\nMay be %s is not healthy?", http.StatusText(resp.StatusCode), s.server)}
+		return &StatusError{
+			req.Method + " " + url + OAuthInfo,
+			resp.StatusCode,
+			fmt.Sprintf("%s\nMay be %s is not healthy?",
+				http.StatusText(resp.StatusCode), s.server),
+		}
 	default:
 		// Any other error
-		return &StatusError{req.Method + " " + url + OAuthInfo, resp.StatusCode, string(respBody)}
+		return &StatusError{
+			req.Method + " " + url + OAuthInfo,
+			resp.StatusCode,
+			string(respBody),
+		}
 	}
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -257,7 +257,8 @@ func (r *Resource) Out(
 func targetURL(atc, team, pipeline, job, buildN, instanceVars string) string {
 	// https://ci.example.com/teams/main/pipelines/cogito/jobs/hello/builds/25
 
-	targetURL := atc + path.Join("/teams", team, "pipelines", pipeline, "jobs", job, "builds", buildN)
+	targetURL := atc +
+		path.Join("/teams", team, "pipelines", pipeline, "jobs", job, "builds", buildN)
 	// targetURL := fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds/%s",
 	// 	atc, team, pipeline, job, buildN)
 
@@ -380,9 +381,10 @@ func checkRepoDir(dir, owner, repo string) error {
 	for i, l := range left {
 		r := right[i]
 		if !strings.EqualFold(l, r) {
-			return fmt.Errorf("resource source configuration and git repository are incompatible.\nGit remote: %q\n"+
-				"Resource config: host: github.com, owner: %q, repo: %q. %w", remote, owner, repo, errWrongRemote,
-			)
+			return fmt.Errorf(`resource source configuration and git repository are incompatible.
+Git remote: %q
+Resource config: host: github.com, owner: %q, repo: %q. %w`,
+				remote, owner, repo, errWrongRemote)
 		}
 	}
 	return nil

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -95,7 +95,9 @@ func TestIn(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := Resource{}
 
-			version, metadata, err := r.In("/tmp", defSource, oc.Params{}, tc.inVersion, defEnv, silentLog)
+			version, metadata, err := r.In(
+				"/tmp", defSource, oc.Params{}, tc.inVersion, defEnv, silentLog,
+			)
 
 			if err != nil {
 				t.Fatalf("err: got %v; want %v", err, nil)
@@ -209,23 +211,25 @@ func TestOut(t *testing.T) {
 			inDir, teardown := setup(t, defDir, sshRemote(cfg.Owner, cfg.Repo), cfg.SHA, cfg.SHA)
 			defer teardown(t)
 
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusCreated)
-				fmt.Fprintln(w, "Anything goes...")
+			ts := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusCreated)
+					fmt.Fprintln(w, "Anything goes...")
 
-				if tc.want.body != nil {
-					buf, _ := io.ReadAll(r.Body)
-					var bm map[string]string
-					if err := json.Unmarshal(buf, &bm); err != nil {
-						t.Fatalf("parsing JSON body: %v", err)
-					}
-					for k, v := range tc.want.body {
-						if bm[k] != v {
-							t.Errorf("\nbody[%q]: got: %q; want: %q", k, bm[k], v)
+					if tc.want.body != nil {
+						buf, _ := io.ReadAll(r.Body)
+						var bm map[string]string
+						if err := json.Unmarshal(buf, &bm); err != nil {
+							t.Fatalf("parsing JSON body: %v", err)
+						}
+						for k, v := range tc.want.body {
+							if bm[k] != v {
+								t.Errorf("\nbody[%q]: got: %q; want: %q", k, bm[k], v)
+							}
 						}
 					}
-				}
-			}))
+				}),
+			)
 
 			savedAPI := github.API
 			github.API = ts.URL
@@ -241,7 +245,8 @@ func TestOut(t *testing.T) {
 			gotErrType := reflect.TypeOf(err)
 			wantErrType := reflect.TypeOf(tc.want.err)
 			if gotErrType != wantErrType {
-				t.Fatalf("\ngot: %v (%v)\nwant: %v (%v)", gotErrType, err, wantErrType, tc.want.err)
+				t.Fatalf("\ngot: %v (%v)\nwant: %v (%v)",
+					gotErrType, err, wantErrType, tc.want.err)
 			}
 
 			if diff := cmp.Diff(tc.want.version, version); diff != "" {


### PR DESCRIPTION
I also added Task target `lint:linelength`, but it is not hooked to CI because
the tool used sometimes makes wrong decisions. In this PR, I ran it and then decided
how to approach each of the suggested changes.