### PR TITLE
github/status test: cleanups

### DIFF
--- a/github/status.go
+++ b/github/status.go
@@ -63,7 +63,7 @@ func NewStatus(server, token, owner, repo, context string) status {
 // Parameter targetURL (optional) points to the specific process (for example, a CI build)
 // that generated this state.
 // Parameter description (optional) gives more information about the status.
-// The returned error contains some diagnostic information to troubleshoot.
+// The returned error contains some diagnostic information to help troubleshooting.
 func (s status) Add(sha, state, targetURL, description string) error {
 	// API: POST /repos/:owner/:repo/statuses/:sha
 	url := s.server + path.Join("/repos", s.owner, s.repo, "statuses", sha)

--- a/github/status.go
+++ b/github/status.go
@@ -142,23 +142,23 @@ One of the following happened:
 `,
 			path.Join(s.owner, s.repo))
 		return &StatusError{
-			req.Method + " " + url + msg + OAuthInfo,
-			resp.StatusCode,
-			fmt.Sprintf("%s\n%s", http.StatusText(resp.StatusCode), string(respBody)),
+			What:       req.Method + " " + url + msg + OAuthInfo,
+			StatusCode: resp.StatusCode,
+			Details:    fmt.Sprintf("%s\n%s", http.StatusText(resp.StatusCode), string(respBody)),
 		}
 	case http.StatusInternalServerError:
 		return &StatusError{
-			req.Method + " " + url + OAuthInfo,
-			resp.StatusCode,
-			fmt.Sprintf("%s\nMay be %s is not healthy?",
+			What:       req.Method + " " + url + OAuthInfo,
+			StatusCode: resp.StatusCode,
+			Details: fmt.Sprintf("%s\nMay be %s is not healthy?",
 				http.StatusText(resp.StatusCode), s.server),
 		}
 	default:
 		// Any other error
 		return &StatusError{
-			req.Method + " " + url + OAuthInfo,
-			resp.StatusCode,
-			string(respBody),
+			What:       req.Method + " " + url + OAuthInfo,
+			StatusCode: resp.StatusCode,
+			Details:    string(respBody),
 		}
 	}
 }

--- a/github/status_test.go
+++ b/github/status_test.go
@@ -66,13 +66,13 @@ func TestGitHubStatusFailureMockAPI(t *testing.T) {
 		wantStatus int
 	}{
 		{
-			name:       "Server error",
+			name:       "500 Internal Server Error",
 			body:       "Something bad happened!",
 			wantErr:    http.StatusText(http.StatusInternalServerError),
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
-			name: "Repo not found",
+			name: "404 Not Found (multiple causes)",
 			body: "Repo not found",
 			wantErr: fmt.Sprintf(`
 One of the following happened:

--- a/github/status_test.go
+++ b/github/status_test.go
@@ -96,10 +96,12 @@ One of the following happened:
 		t.Run(tc.name, func(t *testing.T) {
 			ghStatus := github.NewStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context)
 			err := ghStatus.Add(cfg.SHA, state, targetURL, desc)
-			if err != nil {
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("\nhave: %v\nwant: %v", err, tc.wantErr)
-				}
+			if err == nil {
+				t.Fatalf("\nhave: <no error>\nwant: %s", tc.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("\nhave: %v\nwant: %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/github/status_test.go
+++ b/github/status_test.go
@@ -15,7 +15,44 @@ import (
 	"github.com/Pix4D/cogito/help"
 )
 
-func TestGitHubStatusMockAPI(t *testing.T) {
+func TestGitHubStatusSuccessMockAPI(t *testing.T) {
+	cfg := help.FakeTestCfg
+	context := "cogito/test"
+	targetURL := "https://cogito.invalid/builds/job/42"
+	desc := time.Now().Format("15:04:05")
+	state := "success"
+
+	var testCases = []struct {
+		name   string
+		body   string
+		status int
+	}{
+		{
+			name:   "No errors",
+			body:   "Anything goes...",
+			status: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range testCases {
+		ts := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprintln(w, tc.body)
+			}))
+		defer ts.Close()
+
+		t.Run(tc.name, func(t *testing.T) {
+			ghStatus := github.NewStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context)
+			err := ghStatus.Add(cfg.SHA, state, targetURL, desc)
+			if err != nil {
+				t.Fatalf("\nhave: %s\nwant: <no error>", err)
+			}
+		})
+	}
+}
+
+func TestGitHubStatusFailureMockAPI(t *testing.T) {
 	cfg := help.FakeTestCfg
 	context := "cogito/test"
 	targetURL := "https://cogito.invalid/builds/job/42"
@@ -29,15 +66,9 @@ func TestGitHubStatusMockAPI(t *testing.T) {
 		wantStatus int
 	}{
 		{
-			name:       "No errors",
-			body:       "Anything goes...",
-			wantErr:    "",
-			wantStatus: http.StatusCreated,
-		},
-		{
 			name:       "Server error",
 			body:       "Something bad happened!",
-			wantErr:    http.StatusText(500),
+			wantErr:    http.StatusText(http.StatusInternalServerError),
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
@@ -61,12 +92,13 @@ One of the following happened:
 				fmt.Fprintln(w, tc.body)
 			}))
 		defer ts.Close()
+
 		t.Run(tc.name, func(t *testing.T) {
-			status := github.NewStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context)
-			err := status.Add(cfg.SHA, state, targetURL, desc)
+			ghStatus := github.NewStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context)
+			err := ghStatus.Add(cfg.SHA, state, targetURL, desc)
 			if err != nil {
 				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("\ngot:  %v\nwant: %v", err, tc.wantErr)
+					t.Fatalf("\nhave: %v\nwant: %v", err, tc.wantErr)
 				}
 			}
 		})
@@ -87,7 +119,7 @@ func TestGitHubStatusIntegration(t *testing.T) {
 	err := status.Add(cfg.SHA, state, targetURL, desc)
 
 	if err != nil {
-		t.Fatalf("\ngot:  %v\nwant: no error", err)
+		t.Fatalf("\nhave: %v\nwant: no error", err)
 	}
 }
 
@@ -125,12 +157,12 @@ func TestUnderstandGitHubStatusFailuresIntegration(t *testing.T) {
 			var statusErr *github.StatusError
 			if errors.As(err, &statusErr) {
 				if statusErr.StatusCode != tc.wantStatus {
-					t.Fatalf("status code: got %v (%v); want %v (%v)\n%v",
+					t.Fatalf("status code: have %v (%v); want %v (%v)\n%v",
 						statusErr.StatusCode, http.StatusText(statusErr.StatusCode),
 						tc.wantStatus, http.StatusText(tc.wantStatus), err)
 				}
 			} else {
-				t.Fatalf("got %v; want *github.StatusError", reflect.TypeOf(err))
+				t.Fatalf("have %v; want *github.StatusError", reflect.TypeOf(err))
 			}
 		})
 	}


### PR DESCRIPTION
Best reviewed commit-per-commit:

- github/status: cosmetic changes (refactor: no behavioral changes)
- github/status test: refactor: split tests in success and failure 
  This simplifies the tests and makes it easier to spot errors.
- github/status test: fix bug in test

Part of PCI-2267