### PR TITLE
github/status: more user-friendly errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED - xxxx-xx-xx
 
+### Fixed
+
+- Return more user-friendly errors from the github/status API.
+
 ## [v0.6.1] - 2022-01-06
 
 ### Breaking
@@ -22,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Return standard error description in addition to the error code. 
+- Return standard error description in addition to the error code from the github/status API.
 
 ## [v0.6.0] - 2021-08-26
 

--- a/github/status_test.go
+++ b/github/status_test.go
@@ -65,24 +65,37 @@ func TestGitHubStatusFailureMockAPI(t *testing.T) {
 		wantStatus int
 	}{
 		{
+			name: "404 Not Found (multiple causes)",
+			body: "fake body",
+			wantErr: `Failed to add state "success" for commit 0123456: 404 Not Found
+Body: fake body
+Hint: one of the following happened:
+    1. The repo https://github.com/fakeOwner/fakeRepo doesn't exist
+    2. The user who issued the token doesn't have write access to the repo
+    3. The token doesn't have scope repo:status
+Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
+OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
+			wantStatus: http.StatusNotFound,
+		},
+		{
 			name: "500 Internal Server Error",
 			body: "fake body",
-			wantErr: `POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789 X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: [], status 500 (Internal Server Error
-May be %[1]s is not healthy?)`,
+			wantErr: `Failed to add state "success" for commit 0123456: 500 Internal Server Error
+Body: fake body
+Hint: Github API is down
+Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
+OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
-			name: "404 Not Found (multiple causes)",
+			name: "Any other error",
 			body: "fake body",
-			wantErr: `POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
-One of the following happened:
-    1. The repo https://github.com/fakeOwner/fakeRepo doesn't exist
-	2. The user who issued the token doesn't have write access to the repo
-	3. The token doesn't have scope repo:status
- X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: [], status 404 (Not Found
-fake body
-)`,
-			wantStatus: http.StatusNotFound,
+			wantErr: `Failed to add state "success" for commit 0123456: 418 I'm a teapot
+Body: fake body
+Hint: none
+Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
+OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
+			wantStatus: http.StatusTeapot,
 		},
 	}
 


### PR DESCRIPTION
I realized that when I first added this code, I was focusing on helping me (the developer) understanding the Github API, instead of focusing on helping the user understand what went wrong in production. Subsequent PRs added their own quirks.

See the tests for more examples.

Example before:

    POST http://127.0.0.1:55971/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
    One of the following happened:
        1. The repo https://github.com/fakeOwner/fakeRepo doesn't exist
        2. The user who issued the token doesn't have write access to the repo
        3. The token doesn't have scope repo:status
    X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: [], status 404 (Not Found
    fake body
    )

Example now:

    Failed to add state "success" for commit 0123456: 404 Not Found
    Body: fake body
    Hint: one of the following happened:
        1. The repo https://github.com/fakeOwner/fakeRepo doesn't exist
        2. The user who issued the token doesn't have write access to the repo
        3. The token doesn't have scope repo:status
    Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
    OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []

Part of PCI-2267