### PR TITLE
Support git remote URL with encoded basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED - xxxx-xx-xx
 
+### Added
+
+- Support the case where the git remote URL contains basic auth information (this doesn't happen with the Concourse git resource, but can happen with a PR resource, see #46 for a discussion).
+  Thanks @Mike-Dax for the initial implementation (#46).
+
+### Changed
+
+- Extensive code and tests refactoring.
+
 ### Fixed
 
 - Return more user-friendly errors from the github/status API.
-- Return more user-friendly errors when validating the configuration.
+- Return more user-friendly errors when validating the Cogito and git configuration.
 
 ## [v0.6.1] - 2022-01-06
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -186,7 +186,7 @@ func (r *Resource) Out(
 	team := env.Get("BUILD_TEAM_NAME")
 	buildN := env.Get("BUILD_NAME")
 	instanceVars := env.Get("BUILD_PIPELINE_INSTANCE_VARS")
-	targetURL := targetURL(atc, team, pipeline, job, buildN, instanceVars)
+	targetURL := ghTargetURL(atc, team, pipeline, job, buildN, instanceVars)
 	description := "Build " + buildN
 	log.Debugf(`out: posting:
   state: %v
@@ -210,7 +210,9 @@ func (r *Resource) Out(
 	return dummyVersion, metadata, nil
 }
 
-func targetURL(atc, team, pipeline, job, buildN, instanceVars string) string {
+// ghTargetURL builds an URL suitable to be used as the target_url parameter for the
+// Github commit status API.
+func ghTargetURL(atc, team, pipeline, job, buildN, instanceVars string) string {
 	// https://ci.example.com/teams/main/pipelines/cogito/jobs/hello/builds/25
 
 	targetURL := atc +

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -496,7 +496,7 @@ Cogito SOURCE configuration:
 	}
 }
 
-func TestTargetURL(t *testing.T) {
+func TestGhTargetURL(t *testing.T) {
 	testCases := []struct {
 		name         string
 		atc          string
@@ -549,7 +549,9 @@ func TestTargetURL(t *testing.T) {
 				buildN = tc.buildN
 			}
 
-			if have := targetURL(atc, team, pipeline, job, buildN, tc.instanceVars); have != tc.want {
+			have := ghTargetURL(atc, team, pipeline, job, buildN, tc.instanceVars)
+
+			if have != tc.want {
 				t.Fatalf("\nhave: %s\nwant: %s", have, tc.want)
 			}
 		})

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -624,6 +624,11 @@ func TestCheckRepoDirSuccess(t *testing.T) {
 			dir:     "a-repo",
 			repoURL: httpRemote(wantOwner, wantRepo),
 		},
+		{
+			name:    "PR resource but with basic auth in URL (see PR #46)",
+			dir:     "a-repo",
+			repoURL: "https://x-oauth-basic:ghp_XXX@github.com/smiling/butterfly.git",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -697,21 +702,6 @@ Cogito SOURCE configuration:
 			dir:         "a-repo",
 			repoURL:     "foo://bar",
 			wantErrWild: `.git/config: remote: invalid git URL foo://bar: invalid scheme: foo`,
-		},
-		{
-			name:    "PR resource mimicking the git resource (see PR #46)",
-			dir:     "a-repo",
-			repoURL: "https://x-oauth-basic:ghp_XXX@github.com/smiling/butterfly.git",
-			wantErrWild: `the received git repository is incompatible with the Cogito configuration.
-
-Git repository configuration (received as 'inputs:' in this PUT step):
-      url: https://x-oauth-basic:ghp_XXX@github.com/smiling/butterfly.git
-    owner: smiling
-     repo: butterfly
-
-Cogito SOURCE configuration:
-    owner: smiling
-     repo: butterfly`,
 		},
 	}
 


### PR DESCRIPTION
Best reviewed commit per commit.

- resource: rename and document targetURL.
- resource: rewrite parseGitPseudoURL to use url.Parse from stdlib
  - This gives better error messages, solves #46 in another way and will make it easier to extend to Enterprise Github, where the host is not githib.com
- resource:parseGitPseudoURL: move the failing test to passing test
  - This confirms that now we support a PR resource that puts basic auth in the git URL (see #46).

Part of PCI-2274

This also solves in another way #46.
