### PR TITLE
Run forgotten integration tests :-(

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,7 @@ tasks:
   test:integration:
     desc: Run the integration tests.
     cmds:
-      - go test -count=1 -run 'Test.*Integration$' -coverprofile=coverage.out ./...
+      - go test -count=1 -run 'Test.*Integration.*' -coverprofile=coverage.out ./...
     env: *test-env
 
   test:all:

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -396,7 +396,7 @@ func TestOutMockFailure(t *testing.T) {
 	}
 }
 
-func TestOutIntegrationSuccess(t *testing.T) {
+func TestOutSuccessIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -437,7 +437,7 @@ func TestOutIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestOutIntegrationFailure(t *testing.T) {
+func TestOutFailureIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
Before:

ok  	github.com/Pix4D/cogito/github	0.379s	coverage: 84.4% of statements
ok  	github.com/Pix4D/cogito/resource	0.004s	coverage: 0.0% of statements [no tests to run]

After:

ok  	github.com/Pix4D/cogito/github	0.356s	coverage: 84.4% of statements
ok  	github.com/Pix4D/cogito/resource	0.203s	coverage: 68.5% of statements

Part of PCI-2071