### PR TITLE
ci: run forgotten integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
       - run: task ci:setup
       - run: task lint
       - run: task build
-      - run: task test:unit
-      - run: task test:integration
+      - run: task test:all
         env:
           COGITO_TEST_OAUTH_TOKEN: ${{ secrets.COGITO_TEST_OAUTH_TOKEN }}
       - run: task docker:build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ cogito/
 We are finally ready to run the integration tests:
 
 ```
-$ task test:integration
+$ task test:all
 ```
 
 The integration tests have the following logic:
@@ -173,7 +173,7 @@ Simply have a look at the contents of [.github/workflows/ci.yml](.github/workflo
 Run the tests
 
 ```console
-$ task test:unit test:integration
+$ task test:all
 ```
 
 Build the Docker image

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # cogito
 
-[![Travis Build Status](https://travis-ci.org/Pix4D/cogito.svg?branch=master)](https://travis-ci.org/Pix4D/cogito)
-
 Cogito (**Co**ncourse **git** status res**o**urce) is a [Concourse resource] to update the GitHub status of a commit during a build. The name is a humble homage to [René Descartes].
 
 Written in Go, it has the following characteristics:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
       - golines --max-len=99 --write-output .
 
   test:env:
-    desc: "Run what is passed on the command-line with a shell environment containing the secrets needed for the integration tests. Example: task test:env -- go test -count=1 -run '^TestFooIntegration' ./pkg/update"
+    desc: "Run what is passed on the command-line with a shell environment containing the secrets needed for the integration tests. Example: task test:env -- go test -count=1 -run 'TestFooIntegration' ./pkg/update"
     cmds:
       - '{{ .CLI_ARGS }}'
     env: &test-env
@@ -55,12 +55,6 @@ tasks:
     desc: Run the unit tests.
     cmds:
       - go test -count=1 -short -coverprofile=coverage.out ./...
-
-  test:integration:
-    desc: Run the integration tests.
-    cmds:
-      - go test -count=1 -run 'Test.*Integration$' -coverprofile=coverage.out ./...
-    env: *test-env
 
   test:all:
     desc: Run all the tests (unit + integration). Use this target to get total coverage.

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -396,7 +396,7 @@ func TestOutMockFailure(t *testing.T) {
 	}
 }
 
-func TestOutIntegrationSuccess(t *testing.T) {
+func TestOutSuccessIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -437,7 +437,7 @@ func TestOutIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestOutIntegrationFailure(t *testing.T) {
+func TestOutFailureIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
Replaces #73

Also remove target test:integration, since it had two defects:
- it made this bug possible
- it made it impossible to see the whole test coverage

Now the recommended workflow is:

Run only unit tests:

    task test:unit

Run all tests (and get correct code coverage):

    task test:all

Part of PCI-2071