### PR TITLE
Remove ofcourse 2: provide debug info as soon as possible, defer input validation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,6 +19,12 @@ vars:
   BUILD_INFO: "Tag: {{.DOCKER_TAG}}, commit: {{.COMMIT}}, build date: {{.DATE}}"
   LDFLAGS: -w -X '{{.REPO}}/resource.buildinfo={{.BUILD_INFO}}'
   #
+  SMOKE_INPUT: >
+    {
+      "source": {"owner": "foo", "repo": "bar", "access_token": "123", "log_level": "debug"},
+      "version": {"ref": "pizza"}
+    }
+  #
   GOLANGCI_VERSION: v1.46.0
   GOLINES_VERSION: v0.9.0
 
@@ -63,6 +69,14 @@ tasks:
     cmds:
       - go test -count=1 -coverprofile=coverage.out ./...
     env: *test-env
+
+  test:smoke:
+    desc: Simple smoke test of the local executables.
+    cmds:
+      - echo '{{.SMOKE_INPUT}}' | ./bin/check
+      - echo
+      - echo '{{.SMOKE_INPUT}}' | ./bin/in dummy-dir
+      - echo
 
   browser:
     desc: "Show code coverage in browser (usage: task test:<subtarget> browser)"
@@ -109,12 +123,10 @@ tasks:
   docker:smoke:
     desc: Simple smoke test of the Docker image.
     cmds:
-      - echo '{{.INPUT}}' | docker run --rm --interactive {{.DOCKER_FULL_NAME}} /opt/resource/check
+      - echo '{{.SMOKE_INPUT}}' | docker run --rm --interactive {{.DOCKER_FULL_NAME}} /opt/resource/check
       - echo
-      - echo '{{.INPUT}}' | docker run --rm --interactive {{.DOCKER_FULL_NAME}} /opt/resource/in dummy
+      - echo '{{.SMOKE_INPUT}}' | docker run --rm --interactive {{.DOCKER_FULL_NAME}} /opt/resource/in dummy-dir
       - echo
-    vars:
-      INPUT: '{ "source": { "owner": "foo", "repo": "bar", "access_token": "123", "log_level": "debug"} }'
 
   docker:push:
     desc: Push the Docker image.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,6 +62,7 @@ tasks:
   test:unit:
     desc: Run the unit tests.
     cmds:
+      # One day I will understand how to use -coverpkg=./... :-(
       - go test -count=1 -short -coverprofile=coverage.out ./...
 
   test:all:

--- a/cogito/utils_test.go
+++ b/cogito/utils_test.go
@@ -30,7 +30,8 @@ func fromJSON(t *testing.T, data []byte, thing any) {
 // merged copy. If s has only one element, mergeStructs returns it unmodified.
 // Used to express succinctly the delta in the test cases.
 func mergeStructs[E any](t *testing.T, s []E) E {
-	assert.Assert(t, len(s) == 1 || len(s) == 2)
+	t.Helper()
+	assert.Assert(t, len(s) == 1 || len(s) == 2, len(s))
 	want := s[0]
 	if len(s) == 2 {
 		err := mergo.Merge(&want, s[1], mergo.WithOverride)
@@ -42,6 +43,6 @@ func mergeStructs[E any](t *testing.T, s []E) E {
 // failingWriter is an io.Writer that always returns an error.
 type failingWriter struct{}
 
-func (t *failingWriter) Write(p []byte) (n int, err error) {
-	return 0, errors.New("no bananas")
+func (t *failingWriter) Write([]byte) (n int, err error) {
+	return 0, errors.New("test write error")
 }


### PR DESCRIPTION
This changes the logic of previous PR https://github.com/Pix4D/cogito/pull/85 and makes the code a bit more complicated, with the goal of providing more debug information if something goes wrong at input validation time.

This chicken-and-egg problem is due to the fact that logging configuration is passed
too late, at the same time as all the other resource Source configuration, so to give
as much debugging information as possible we need to get the log level as soon as
possible, also if the Source has other errors. This cannot be simplified, we are
working within the limits of the Concourse resource protocol.

PCI-2587