### PR TITLE
Prepare override of chat states

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ resource_types:
 resources:
 - name: gh-status
   type: cogito
-  check_every: 24h
+  check_every: never
   source:
     owner: ((github-owner))
     repo: ((your-repo-name))
@@ -116,7 +116,7 @@ The absolute minimum is adding key `gchat_webhook` to the `source` configuration
 ```yaml
 - name: gh-status
   type: cogito
-  check_every: 24h
+  check_every: never
   source:
     owner: ((github-owner))
     repo: ((your-repo-name))

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -156,7 +156,7 @@ func TestRunFailure(t *testing.T) {
 {
   "fruit": "banana" 
 }`,
-			wantErr: `check: parsing JSON from stdin: json: unknown field "fruit"`,
+			wantErr: `check: parsing request: json: unknown field "fruit"`,
 		},
 	}
 

--- a/cogito/check.go
+++ b/cogito/check.go
@@ -17,13 +17,12 @@ import (
 // It is given the configured source and current version on stdin, and must print the
 // array of new versions, in chronological order (oldest first), to stdout, including
 // the requested version if it is still valid.
-//
 func Check(log hclog.Logger, in io.Reader, out io.Writer, args []string) error {
 	var request CheckRequest
 	dec := json.NewDecoder(in)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&request); err != nil {
-		return fmt.Errorf("check: parsing JSON from stdin: %s", err)
+		return fmt.Errorf("check: parsing request: %s", err)
 	}
 	request.Env.Fill()
 

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -116,7 +116,7 @@ func TestCheckFailure(t *testing.T) {
 			source:  cogito.Source{},
 			reader:  iotest.ErrReader(errors.New("test read error")),
 			writer:  io.Discard,
-			wantErr: "check: parsing JSON from stdin: test read error",
+			wantErr: "check: parsing request: test read error",
 		},
 	}
 

--- a/cogito/get.go
+++ b/cogito/get.go
@@ -24,13 +24,12 @@ import (
 // The program must emit a JSON object containing the fetched version, and may emit
 // metadata as a list of key-value pairs.
 // This data is intended for public consumption and will be shown on the build page.
-//
 func Get(log hclog.Logger, in io.Reader, out io.Writer, args []string) error {
 	var request GetRequest
 	dec := json.NewDecoder(in)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&request); err != nil {
-		return fmt.Errorf("get: parsing JSON from stdin: %s", err)
+		return fmt.Errorf("get: parsing request: %s", err)
 	}
 	request.Env.Fill()
 

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -130,7 +130,7 @@ func TestGetFailure(t *testing.T) {
 			name:    "system read error",
 			reader:  iotest.ErrReader(errors.New("test read error")),
 			writer:  io.Discard,
-			wantErr: "get: parsing JSON from stdin: test read error",
+			wantErr: "get: parsing request: test read error",
 		},
 	}
 
@@ -147,7 +147,7 @@ func TestGetNonEmptyParamsFailure(t *testing.T) {
   "source": {},
   "params": {"pizza": "margherita"}
 }`)
-	wantErr := `get: parsing JSON from stdin: json: unknown field "params"`
+	wantErr := `get: parsing request: json: unknown field "params"`
 
 	err := cogito.Get(hclog.NewNullLogger(), in, io.Discard, []string{})
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -281,3 +281,43 @@ func TestEnvironment(t *testing.T) {
 	have := fmt.Sprint(env)
 	assert.Assert(t, strings.Contains(have, "banana-mango"), "\n%s", have)
 }
+
+func TestBuildStateUnmarshalJSONSuccess(t *testing.T) {
+	var state cogito.BuildState
+
+	err := state.UnmarshalJSON([]byte(`"pending"`))
+
+	assert.NilError(t, err)
+	assert.Equal(t, state, cogito.StatePending)
+}
+
+func TestBuildStateUnmarshalJSONFailure(t *testing.T) {
+	type testCase struct {
+		name    string
+		data    []byte
+		wantErr string
+	}
+
+	test := func(t *testing.T, tc testCase) {
+		var state cogito.BuildState
+
+		assert.Error(t, state.UnmarshalJSON(tc.data), tc.wantErr)
+	}
+
+	testCases := []testCase{
+		{
+			name:    "no input",
+			data:    nil,
+			wantErr: "unexpected end of JSON input",
+		},
+		{
+			name:    "",
+			data:    []byte(`"pizza"`),
+			wantErr: "invalid build state: pizza",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { test(t, tc) })
+	}
+}

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -123,9 +123,6 @@ func (putter *ProdPutter) LoadConfiguration(in io.Reader, args []string) error {
 	putter.log.Debug("", "input-directory", putter.InputDir)
 
 	buildState := putter.Request.Params.State
-	if err := buildState.Validate(); err != nil {
-		return fmt.Errorf("put: params: %s", err)
-	}
 	putter.log.Debug("", "state", buildState)
 
 	return nil

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -95,7 +95,7 @@ func (putter *ProdPutter) LoadConfiguration(in io.Reader, args []string) error {
 	dec := json.NewDecoder(in)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&putter.Request); err != nil {
-		return fmt.Errorf("put: parsing JSON from stdin: %s", err)
+		return fmt.Errorf("put: parsing request: %s", err)
 	}
 	putter.Request.Env.Fill()
 

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -187,7 +187,7 @@ func TestPutterLoadConfigurationSystemFailure(t *testing.T) {
 
 	err := putter.LoadConfiguration(iotest.ErrReader(errors.New("test read error")), nil)
 
-	assert.Error(t, err, "put: parsing JSON from stdin: test read error")
+	assert.Error(t, err, "put: parsing request: test read error")
 }
 
 func TestPutterLoadConfigurationInvalidParamsFailure(t *testing.T) {
@@ -196,7 +196,7 @@ func TestPutterLoadConfigurationInvalidParamsFailure(t *testing.T) {
   "source": {},
   "params": {"pizza": "margherita"}
 }`)
-	wantErr := `put: parsing JSON from stdin: json: unknown field "pizza"`
+	wantErr := `put: parsing request: json: unknown field "pizza"`
 	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -150,13 +150,14 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     "source: missing keys",
-			putInput: cogito.PutRequest{Source: cogito.Source{}},
+			putInput: cogito.PutRequest{Source: cogito.Source{}, Params: baseParams},
 			wantErr:  "put: source: missing keys: owner, repo, access_token",
 		},
 		{
 			name: "source: invalid log_level",
 			putInput: cogito.PutRequest{
 				Source: testhelp.MergeStructs(baseSource, cogito.Source{LogLevel: "pippo"}),
+				Params: baseParams,
 			},
 			wantErr: "put: source: invalid log_level: pippo",
 		},
@@ -166,12 +167,11 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 				Source: baseSource,
 				Params: cogito.PutParams{State: "burnt-pizza"},
 			},
-			args:    []string{"dummy-dir"},
-			wantErr: "put: params: invalid build state: burnt-pizza",
+			wantErr: "put: parsing request: invalid build state: burnt-pizza",
 		},
 		{
 			name:     "arguments: missing input directory",
-			putInput: cogito.PutRequest{Source: baseSource},
+			putInput: basePutInput,
 			args:     []string{},
 			wantErr:  "put: arguments: missing input directory",
 		},

--- a/pipelines/cogito.yml
+++ b/pipelines/cogito.yml
@@ -22,17 +22,20 @@ resource_types:
 
 - name: cogito
   type: registry-image
-  check_every: 24h
+  # For production use, `24h` is a good tradeoff to get a new release with a maximum delay
+  # of 24h. Here we parametrize it to work around a concourse bug when doing development.
+  # See CONTRIBUTING for details
+  check_every: ((cogito-image-check_every))
   source:
     repository: pix4d/cogito
-    tag: ((tag))
+    tag: ((cogito-tag))
 
 resources:
 
 - name: gh-status
   type: cogito
-  # Since check is a no-op, we check infrequently to reduce load on the system.
-  check_every: 24h
+  # Since check is a no-op, we do not check, to reduce load on the system.
+  check_every: never
   source:
     # Optional, for debugging only.
     log_level: debug


### PR DESCRIPTION
This PR contains two somewhat unrelated cleanups: (1) document some more release workarounds (2) introduce custom JSON parsing for `build_state` to keep type safety and auto-validate.

Better reviewed commit per commit.

- doc: more workarounds for concourse bug not picking up latest
- BuildState: add custom unmarshaller for validation
    This also means that we can remove the explicit call to BuildState.Validate() in
    ProdPutter.LoadConfiguration(), since it will be done by the JSON parser when
    it encounters the BuildState type as a field of struct PutRequest.

PCI-2586