### PR TITLE
Safe parse URL to not leak password in case of error

### DIFF
--- a/cogito/put.go
+++ b/cogito/put.go
@@ -2,6 +2,7 @@ package cogito
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -274,14 +275,32 @@ type gitURL struct {
 	Repo  string
 }
 
+// safeParseUrl parse the given URL and return an error if the URL is not well formated.
+// this avoid to eventually leak passwords in case of error
+//
+// From https://github.com/golang/go/issues/53993
+func safeParse(rawURL string) (*url.URL, error) {
+	parsedUrl, err := url.Parse(rawURL)
+	if err != nil {
+		// check if the returned error is actually of type url.Error
+		if uerr := new(url.Error); errors.As(err, &uerr) {
+			// return only the Err and not the URL to not leak potential passwords
+			return nil, uerr.Err
+		}
+		// default error
+		return nil, errors.New("invalid URL")
+	}
+	return parsedUrl, nil
+}
+
 // parseGitPseudoURL attempts to parse rawURL as a git remote URL compatible with the
 // Github naming conventions.
 //
 // It supports the following types of git pseudo URLs:
 //   - ssh:   git@github.com:Pix4D/cogito.git; will be rewritten to the valid URL
 //     ssh://git@github.com/Pix4D/cogito.git
-//   - https: https://github.com/Pix4D/cogito.git
-//   - http:  http://github.com/Pix4D/cogito.git
+//   - https: https://github.com/Pix4D/cogito.git or https://username:password@github.com/Pix4D/cogito.git
+//   - http: http://github.com/Pix4D/cogito.git or http://username:password@github.com/Pix4D/cogito.git
 func parseGitPseudoURL(rawURL string) (gitURL, error) {
 	workURL := rawURL
 	// If ssh pseudo URL, we need to massage the rawURL ourselves :-(
@@ -294,7 +313,7 @@ func parseGitPseudoURL(rawURL string) (gitURL, error) {
 		workURL = "ssh://" + strings.Replace(workURL, ":", "/", 1)
 	}
 
-	anyUrl, err := url.Parse(workURL)
+	anyUrl, err := safeParse(workURL)
 	if err != nil {
 		return gitURL{}, err
 	}

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -282,7 +282,8 @@ type gitURL struct {
 func safeUrlParse(rawURL string) (*url.URL, error) {
 	parsedUrl, err := url.Parse(rawURL)
 	if err != nil {
-		if uerr := new(url.Error); errors.As(err, &uerr) {
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
 			// url.Parse returns a wrapped error that contains also the URL. Instead, we return only the error.
 			return nil, uerr.Err
 		}

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -284,7 +284,8 @@ func safeUrlParse(rawURL string) (*url.URL, error) {
 	if err != nil {
 		var uerr *url.Error
 		if errors.As(err, &uerr) {
-			// url.Parse returns a wrapped error that contains also the URL. Instead, we return only the error.
+			// url.Parse returns a wrapped error that contains also the URL.
+			// Instead, we return only the error.
 			return nil, uerr.Err
 		}
 		return nil, errors.New("invalid URL")

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -275,19 +275,17 @@ type gitURL struct {
 	Repo  string
 }
 
-// safeParseUrl parse the given URL and return an error if the URL is not well formated.
-// this avoid to eventually leak passwords in case of error
+// safeUrlParse wraps [url.Parse] and returns only the error and not the URL to avoid leaking
+// passwords of the form http://user:password@example.com
 //
 // From https://github.com/golang/go/issues/53993
-func safeParse(rawURL string) (*url.URL, error) {
+func safeUrlParse(rawURL string) (*url.URL, error) {
 	parsedUrl, err := url.Parse(rawURL)
 	if err != nil {
-		// check if the returned error is actually of type url.Error
 		if uerr := new(url.Error); errors.As(err, &uerr) {
-			// return only the Err and not the URL to not leak potential passwords
+			// url.Parse returns a wrapped error that contains also the URL. Instead, we return only the error.
 			return nil, uerr.Err
 		}
-		// default error
 		return nil, errors.New("invalid URL")
 	}
 	return parsedUrl, nil
@@ -297,10 +295,12 @@ func safeParse(rawURL string) (*url.URL, error) {
 // Github naming conventions.
 //
 // It supports the following types of git pseudo URLs:
-//   - ssh:   git@github.com:Pix4D/cogito.git; will be rewritten to the valid URL
+//   - ssh:   			git@github.com:Pix4D/cogito.git; will be rewritten to the valid URL
 //     ssh://git@github.com/Pix4D/cogito.git
-//   - https: https://github.com/Pix4D/cogito.git or https://username:password@github.com/Pix4D/cogito.git
-//   - http: http://github.com/Pix4D/cogito.git or http://username:password@github.com/Pix4D/cogito.git
+//   - https: 			https://github.com/Pix4D/cogito.git
+//	 - https with u:p: 	https//username:password@github.com/Pix4D/cogito.git
+//   - http: 			http://github.com/Pix4D/cogito.git
+//   - http with u:p: 	http://username:password@github.com/Pix4D/cogito.git
 func parseGitPseudoURL(rawURL string) (gitURL, error) {
 	workURL := rawURL
 	// If ssh pseudo URL, we need to massage the rawURL ourselves :-(
@@ -313,7 +313,7 @@ func parseGitPseudoURL(rawURL string) (gitURL, error) {
 		workURL = "ssh://" + strings.Replace(workURL, ":", "/", 1)
 	}
 
-	anyUrl, err := safeParse(workURL)
+	anyUrl, err := safeUrlParse(workURL)
 	if err != nil {
 		return gitURL{}, err
 	}

--- a/cogito/put_private_test.go
+++ b/cogito/put_private_test.go
@@ -292,11 +292,13 @@ func TestParseGitPseudoURLFailure(t *testing.T) {
 			wantErr: "invalid git SSH URL git@github.com/Pix4D/cogito.git: want exactly one ':'",
 		},
 		{
+			// currently failing due to the new safeParse method returning only the error
 			name:    "invalid HTTPS URL",
 			inURL:   "https://github.com:Pix4D/cogito.git",
 			wantErr: `parse "https://github.com:Pix4D/cogito.git": invalid port ":Pix4D" after host`,
 		},
 		{
+			// currently failing due to the new safeParse method returning only the error
 			name:    "invalid HTTP URL",
 			inURL:   "http://github.com:Pix4D/cogito.git",
 			wantErr: `parse "http://github.com:Pix4D/cogito.git": invalid port ":Pix4D" after host`,
@@ -310,6 +312,11 @@ func TestParseGitPseudoURLFailure(t *testing.T) {
 			name:    "too many path components",
 			inURL:   "http://github.com/1/2/cogito.git",
 			wantErr: "invalid git URL: path: want: 3 components; have: 4 [ 1 2 cogito.git]",
+		},
+		{
+			name:    "No leaked password in invalid URL with username:password",
+			inURL:   "http://username:password@github.com/Pix4D/cogito.git\n",
+			wantErr: `net/url: invalid control character in URL`,
 		},
 	}
 

--- a/cogito/put_private_test.go
+++ b/cogito/put_private_test.go
@@ -229,11 +229,11 @@ func TestParseGitPseudoURLSuccess(t *testing.T) {
 			},
 		},
 		{
-			name:  "valid HTTP URL with username:password",
-			inURL: "http://username:password@github.com/Pix4D/cogito.git",
+			name:  "valid HTTPS URL with username:password",
+			inURL: "https://username:password@github.com/Pix4D/cogito.git",
 			wantGU: gitURL{
 				URL: &url.URL{
-					Scheme: "http",
+					Scheme: "https",
 					User:   url.UserPassword("username", "password"),
 					Host:   "github.com",
 					Path:   "/Pix4D/cogito.git",
@@ -244,10 +244,10 @@ func TestParseGitPseudoURLSuccess(t *testing.T) {
 		},
 		{
 			name:  "valid HTTP URL with username:password",
-			inURL: "https://username:password@github.com/Pix4D/cogito.git",
+			inURL: "http://username:password@github.com/Pix4D/cogito.git",
 			wantGU: gitURL{
 				URL: &url.URL{
-					Scheme: "https",
+					Scheme: "http",
 					User:   url.UserPassword("username", "password"),
 					Host:   "github.com",
 					Path:   "/Pix4D/cogito.git",

--- a/cogito/put_private_test.go
+++ b/cogito/put_private_test.go
@@ -292,16 +292,14 @@ func TestParseGitPseudoURLFailure(t *testing.T) {
 			wantErr: "invalid git SSH URL git@github.com/Pix4D/cogito.git: want exactly one ':'",
 		},
 		{
-			// currently failing due to the new safeParse method returning only the error
 			name:    "invalid HTTPS URL",
 			inURL:   "https://github.com:Pix4D/cogito.git",
-			wantErr: `parse "https://github.com:Pix4D/cogito.git": invalid port ":Pix4D" after host`,
+			wantErr: `invalid port ":Pix4D" after host`,
 		},
 		{
-			// currently failing due to the new safeParse method returning only the error
 			name:    "invalid HTTP URL",
 			inURL:   "http://github.com:Pix4D/cogito.git",
-			wantErr: `parse "http://github.com:Pix4D/cogito.git": invalid port ":Pix4D" after host`,
+			wantErr: `invalid port ":Pix4D" after host`,
 		},
 		{
 			name:    "too few path components",

--- a/cogito/put_private_test.go
+++ b/cogito/put_private_test.go
@@ -228,6 +228,34 @@ func TestParseGitPseudoURLSuccess(t *testing.T) {
 				Repo:  "cogito",
 			},
 		},
+		{
+			name:  "valid HTTP URL with username:password",
+			inURL: "http://username:password@github.com/Pix4D/cogito.git",
+			wantGU: gitURL{
+				URL: &url.URL{
+					Scheme: "http",
+					User:   url.UserPassword("username", "password"),
+					Host:   "github.com",
+					Path:   "/Pix4D/cogito.git",
+				},
+				Owner: "Pix4D",
+				Repo:  "cogito",
+			},
+		},
+		{
+			name:  "valid HTTP URL with username:password",
+			inURL: "https://username:password@github.com/Pix4D/cogito.git",
+			wantGU: gitURL{
+				URL: &url.URL{
+					Scheme: "https",
+					User:   url.UserPassword("username", "password"),
+					Host:   "github.com",
+					Path:   "/Pix4D/cogito.git",
+				},
+				Owner: "Pix4D",
+				Repo:  "cogito",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Parses a given URL and only returns the error to avoid potential password leaks

Part of PCI-2625

- [x] Merge **only** after fixing tests