### PR TITLE
select which states trigger a notification to the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.1] - UNRELEASED
+
+### Added
+
+- Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.notify_on_states`. Default (as before this tunable): [`abort`, `error`, `failure`].
+
 ## [v0.8.0] - 2022-08-11
 
 ### Changed
@@ -27,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Integration with Google Chat (optional). This allows to reduce the verbosity of a Concourse pipeline and especially to reduce the number of resource containers in a Concourse deployment, thus reducing load.
+- Integration with Google Chat (optional). This allows to reduce the verbosity of a Concourse pipeline and especially to reduce the number of resource containers in a Concourse deployment, thus reducing load. Notification is sent only on states `abort`, `error` and `failure`.
 
 ### Somehow breaking
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
 
 - `context_prefix`: The prefix for the GitHub Commit status API "context" (see section [Effects on GitHub](#effects-on-github)). If present, the context will be `context_prefix/job_name`. Default: empty. See also the optional `context` in the [put step](#the-put-step).
 - `gchat_webhook`. Default: empty. URL of a [Google Chat webhook].
-    A notification about the build status will be sent to the associated chat channel, using a thread key composed by the pipeline name and commit hash.
-    By default, the build statuses that will trigger a notification are `abort`, `error` and `failure`. 
-    See section [Effects on Google Chat](#effects-on-google-chat) (since v0.7.0).
+    A notification about the build status will be sent to the associated chat space, using a thread key composed by the pipeline name and commit hash (since v0.7.0).
+    See also: `notify_on_states` and section [Effects on Google Chat](#effects-on-google-chat).
+- `notify_on_states`. Default: [`abort`, `error`, `failure`]. The build states that will cause a chat notification. One or more of [`abort`, `error`, `failure`, `pending`, `success`].
+  See section [Build states mapping](#build-states-mapping).
 - `log_level`: The log level (one of `debug`, `info`, `warn`, `error`, `silent`). Default: `info`.
 - `log_url`. **DEPRECATED, no-op, will be removed** A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < 7.
 

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -28,7 +28,7 @@ func (sink GoogleChatSink) Send() error {
 	}
 
 	state := sink.Request.Params.State
-	if !shouldSendToChat(state) {
+	if !shouldSendToChat(state, sink.Request.Source.NotifyOnStates) {
 		sink.Log.Debug("not sending to chat",
 			"reason", "state not in enabled states", "state", state)
 		return nil
@@ -55,11 +55,8 @@ func (sink GoogleChatSink) Send() error {
 }
 
 // shouldSendToChat returns true if the state is configured to do so.
-func shouldSendToChat(state BuildState) bool {
-	// States that will trigger a chat notification by default.
-	statesToNotifyChat := []BuildState{StateAbort, StateError, StateFailure}
-
-	for _, x := range statesToNotifyChat {
+func shouldSendToChat(state BuildState, notifyOnStates []BuildState) bool {
+	for _, x := range notifyOnStates {
 		if state == x {
 			return true
 		}

--- a/cogito/gchatsink_private_test.go
+++ b/cogito/gchatsink_private_test.go
@@ -7,6 +7,29 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
+func TestShouldSendToChatDefaultConfig(t *testing.T) {
+	type testCase struct {
+		state BuildState
+		want  bool
+	}
+
+	test := func(t *testing.T, tc testCase) {
+		assert.Equal(t, shouldSendToChat(tc.state), tc.want)
+	}
+
+	testCases := []testCase{
+		{state: StateAbort, want: true},
+		{state: StateError, want: true},
+		{state: StateFailure, want: true},
+		{state: StatePending, want: false},
+		{state: StateSuccess, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.state), func(t *testing.T) { test(t, tc) })
+	}
+}
+
 func TestGChatFormatText(t *testing.T) {
 	type testCase struct {
 		state BuildState

--- a/cogito/gchatsink_private_test.go
+++ b/cogito/gchatsink_private_test.go
@@ -14,7 +14,7 @@ func TestShouldSendToChatDefaultConfig(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		assert.Equal(t, shouldSendToChat(tc.state), tc.want)
+		assert.Equal(t, shouldSendToChat(tc.state, defaultNotifyStates), tc.want)
 	}
 
 	testCases := []testCase{
@@ -23,6 +23,31 @@ func TestShouldSendToChatDefaultConfig(t *testing.T) {
 		{state: StateFailure, want: true},
 		{state: StatePending, want: false},
 		{state: StateSuccess, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.state), func(t *testing.T) { test(t, tc) })
+	}
+}
+
+func TestShouldSendToChatCustomConfig(t *testing.T) {
+	type testCase struct {
+		state BuildState
+		want  bool
+	}
+
+	baseNotifyStates := []BuildState{StatePending, StateSuccess}
+
+	test := func(t *testing.T, tc testCase) {
+		assert.Equal(t, shouldSendToChat(tc.state, baseNotifyStates), tc.want)
+	}
+
+	testCases := []testCase{
+		{state: StateAbort, want: false},
+		{state: StateError, want: false},
+		{state: StateFailure, want: false},
+		{state: StatePending, want: true},
+		{state: StateSuccess, want: true},
 	}
 
 	for _, tc := range testCases {

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -116,6 +116,12 @@ func (putter *ProdPutter) LoadConfiguration(in io.Reader, args []string) error {
 		return fmt.Errorf("put: %s", err)
 	}
 
+	putter.log.Debug("after validation and defaults",
+		"source", putter.Request.Source,
+		"params", putter.Request.Params,
+		"environment", putter.Request.Env,
+		"args", args)
+
 	// args[0] contains the path to a directory containing all the "put inputs".
 	if len(args) == 0 {
 		return fmt.Errorf("put: arguments: missing input directory")

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -22,9 +22,10 @@ var (
 		AccessToken: "the-token",
 	}
 
-	baseParams = cogito.PutParams{State: cogito.StatePending}
+	// StateError is sent to notification sinks by default.
+	baseParams = cogito.PutParams{State: cogito.StateError}
 
-	basePutInput = cogito.PutRequest{
+	basePutRequest = cogito.PutRequest{
 		Source: baseSource,
 		Params: baseParams,
 	}
@@ -122,7 +123,7 @@ func TestPutFailure(t *testing.T) {
 }
 
 func TestPutterLoadConfigurationSuccess(t *testing.T) {
-	in := bytes.NewReader(testhelp.ToJSON(t, basePutInput))
+	in := bytes.NewReader(testhelp.ToJSON(t, basePutRequest))
 	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, []string{"dummy-dir"})
@@ -171,7 +172,7 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 		},
 		{
 			name:     "arguments: missing input directory",
-			putInput: basePutInput,
+			putInput: basePutRequest,
 			args:     []string{},
 			wantErr:  "put: arguments: missing input directory",
 		},

--- a/pipelines/cogito.yml
+++ b/pipelines/cogito.yml
@@ -1,20 +1,44 @@
+# Names are an homage to https://hanna-barbera.fandom.com/wiki/Cattanooga_Cats
+
+# NOTICE
+# In this pipeline we have two cogito resources ONLY BECAUSE this is a test pipeline!
+# In a real pipeline, one cogito resource is always enough. If not, please open an
+#  issue to discuss your use case.
 meta:
 
-  gh-status_handlers: &gh-status-handlers
+  gh-status-1-handlers: &gh-status-1-handlers
     on_success:
-      put: gh-status
+      put: gh-status-1
       inputs: [repo.git]
       params: {state: success}
     on_failure:
-      put: gh-status
+      put: gh-status-1
       inputs: [repo.git]
       params: {state: failure}
     on_error:
-      put: gh-status
+      put: gh-status-1
       inputs: [repo.git]
       params: {state: error}
     on_abort:
-      put: gh-status
+      put: gh-status-1
+      inputs: [repo.git]
+      params: {state: abort}
+
+  gh-status-2-handlers: &gh-status-2-handlers
+    on_success:
+      put: gh-status-2
+      inputs: [repo.git]
+      params: {state: success}
+    on_failure:
+      put: gh-status-2
+      inputs: [repo.git]
+      params: {state: failure}
+    on_error:
+      put: gh-status-2
+      inputs: [repo.git]
+      params: {state: error}
+    on_abort:
+      put: gh-status-2
       inputs: [repo.git]
       params: {state: abort}
 
@@ -32,7 +56,7 @@ resource_types:
 
 resources:
 
-- name: gh-status
+- name: gh-status-1
   type: cogito
   # Since check is a no-op, we do not check, to reduce load on the system.
   check_every: never
@@ -43,6 +67,21 @@ resources:
     repo: ((repo-name))
     access_token: ((oauth-personal-access-token))
     gchat_webhook: ((gchat_webhook))
+
+  # See the NOTICE at the top of this file to understand why we have two cogito resources.
+- name: gh-status-2
+  type: cogito
+  # Since check is a no-op, we do not check, to reduce load on the system.
+  check_every: never
+  source:
+    # Optional, for debugging only.
+    log_level: debug
+    owner: ((github-owner))
+    repo: ((repo-name))
+    access_token: ((oauth-personal-access-token))
+    gchat_webhook: ((gchat_webhook))
+    # These two states make sense only for testing the resource itself...
+    notify_on_states: [pending, success]
 
 - name: repo.git
   type: git
@@ -57,11 +96,11 @@ resources:
 jobs:
 
   - name: autocat
-    <<: *gh-status-handlers
+    <<: *gh-status-1-handlers
     plan:
       - get: repo.git
         trigger: true
-      - put: gh-status
+      - put: gh-status-1
         inputs: [repo.git]
         params: {state: pending}
       - task: will-fail
@@ -80,11 +119,11 @@ jobs:
                 exit 1
 
   - name: motormouse
-    <<: *gh-status-handlers
+    <<: *gh-status-1-handlers
     plan:
       - get: repo.git
         trigger: true
-      - put: gh-status
+      - put: gh-status-1
         inputs: [repo.git]
         params: {state: pending}
       - task: will-succeed
@@ -100,4 +139,27 @@ jobs:
               - |
                 set -o errexit
                 echo Hello from motormouse
+                exit 0
+
+  - name: kitty-jo
+    <<: *gh-status-2-handlers
+    plan:
+      - get: repo.git
+        trigger: true
+      - put: gh-status-2
+        inputs: [repo.git]
+        params: {state: pending}
+      - task: meoooow
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: { repository: alpine }
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                set -o errexit
+                echo Hello from Kitty Jo
                 exit 0


### PR DESCRIPTION
Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.notify_on_states`. Default (as before this tunable): [`abort`, `error`, `failure`].

Update sample pipeline `pipelines/cogito.yml` accordingly.

Closes: PCI-2586
