### PR TITLE
allow to specify a different chat space/webhook during put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.notify_on_states`. Default (as before this tunable): [`abort`, `error`, `failure`].
 - Google Chat: enrich cogito logging with human-readable information about the chat space.
+- Google Chat: allow to specify a different chat space/webhook during put. 
 
 ## [v0.8.0] - 2022-08-11
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ If the `source` block has the optional key `gchat_webhook`, then it will also se
 ## Optional params
 
 - `context`: The value of the non-prefix part of the GitHub Commit status API "context" (see section [Effects on GitHub](#effects-on-github)). Default: the job name. See also the optional `context_prefix` in the [source configuration](#source-configuration).
+- `gchat_webhook`: If present, overrides `source.gchat_webhook`. Default: empty, thus the same as `source.gchat_webhook`. This allows to use the same Cogito resource for multiple chat spaces. 
 
 ## Note
 

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -79,7 +79,7 @@ func (src Source) String() string {
 	fmt.Fprintf(&bld, "gchat_webhook:    %s\n", redact(src.GChatWebHook))
 	fmt.Fprintf(&bld, "log_level:        %s\n", src.LogLevel)
 	fmt.Fprintf(&bld, "context_prefix:   %s\n", src.ContextPrefix)
-	// Last one: no newline
+	// Last one: no newline.
 	fmt.Fprintf(&bld, "notify_on_states: %s", src.NotifyOnStates)
 
 	return bld.String()
@@ -238,7 +238,20 @@ type PutParams struct {
 	//
 	// Optional
 	//
-	Context string `json:"context"`
+	Context      string `json:"context"`
+	GChatWebHook string `json:"gchat_webhook"` // SENSITIVE
+}
+
+// String renders PutParams, redacting the sensitive fields.
+func (params PutParams) String() string {
+	var bld strings.Builder
+
+	fmt.Fprintf(&bld, "state:         %s\n", params.State)
+	fmt.Fprintf(&bld, "context:       %s\n", params.Context)
+	// Last one: no newline.
+	fmt.Fprintf(&bld, "gchat_webhook: %s", redact(params.GChatWebHook))
+
+	return bld.String()
 }
 
 // Environment represents the environment variables made available to the program.

--- a/pipelines/cogito.yml
+++ b/pipelines/cogito.yml
@@ -148,7 +148,9 @@ jobs:
         trigger: true
       - put: gh-status-2
         inputs: [repo.git]
-        params: {state: pending}
+        params:
+          state: pending
+          gchat_webhook: ((gchat_webhook_2))
       - task: meoooow
         config:
           platform: linux


### PR DESCRIPTION
This is obtained with the optional `put.params.gchat_webhook` and allows to use the same
cogito resource for multiple chat spaces.

PCI-2561