### PR TITLE
add a generic set data structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/imdario/mergo v0.3.13
 	github.com/sasbury/mini v0.0.0-20181226232755-dc74af49394b
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	gotest.tools/v3 v3.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/sets/sets.go
+++ b/sets/sets.go
@@ -1,0 +1,80 @@
+// Package sets is a minimal implementation of a generic set data structure.
+
+package sets
+
+import (
+	"fmt"
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
+
+// Set is a minimal set that takes only ordered types: any type that supports the
+// operators < <= >= >.
+type Set[T constraints.Ordered] struct {
+	items map[T]struct{}
+}
+
+// New returns an empty set with capacity size. The capacity will grow and shrink as a
+// stdlib map.
+func New[T constraints.Ordered](size int) *Set[T] {
+	return &Set[T]{items: make(map[T]struct{}, size)}
+}
+
+// From returns a set from elements.
+func From[T constraints.Ordered](elements ...T) *Set[T] {
+	s := New[T](len(elements))
+	for _, i := range elements {
+		s.items[i] = struct{}{}
+	}
+	return s
+}
+
+// String returns a string representation of s, ordered. This allows to simply pass a
+// sets.Set as parameter to a function that expects a fmt.Stringer interface and obtain
+// a comparable string.
+func (s *Set[T]) String() string {
+	return fmt.Sprint(s.OrderedList())
+}
+
+func (s *Set[T]) Size() int {
+	return len(s.items)
+}
+
+// OrderedList returns a slice of the elements of s, ordered.
+// TODO This can probably be replaced in Go 1.20 when a generics slice packages reaches
+// the stdlib.
+func (s *Set[T]) OrderedList() []T {
+	elements := make([]T, 0, len(s.items))
+	for e := range s.items {
+		elements = append(elements, e)
+	}
+	sort.Slice(elements, func(i, j int) bool {
+		return elements[i] < elements[j]
+	})
+	return elements
+}
+
+// Contains returns true if s contains item.
+func (s *Set[T]) Contains(item T) bool {
+	_, found := s.items[item]
+	return found
+}
+
+// Difference returns a set containing the elements of s that are not in x.
+func (s *Set[T]) Difference(x *Set[T]) *Set[T] {
+	result := New[T](max(0, s.Size()-x.Size()))
+	for i := range s.items {
+		if !x.Contains(i) {
+			result.items[i] = struct{}{}
+		}
+	}
+	return result
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/sets/sets_test.go
+++ b/sets/sets_test.go
@@ -1,0 +1,142 @@
+package sets_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Pix4D/cogito/sets"
+	"gotest.tools/v3/assert"
+)
+
+func TestFromInt(t *testing.T) {
+	type testCase struct {
+		name       string
+		items      []int
+		wantSize   int
+		wantList   []int
+		wantString string
+	}
+
+	test := func(t *testing.T, tc testCase) {
+		s := sets.From(tc.items...)
+		sorted := s.OrderedList()
+
+		assert.Equal(t, s.Size(), tc.wantSize)
+		assert.DeepEqual(t, sorted, tc.wantList)
+		assert.Equal(t, fmt.Sprint(s), tc.wantString)
+	}
+
+	testCases := []testCase{
+		{
+			name:       "nil",
+			items:      nil,
+			wantSize:   0,
+			wantList:   []int{},
+			wantString: "[]",
+		},
+		{
+			name:       "empty",
+			items:      []int{},
+			wantSize:   0,
+			wantList:   []int{},
+			wantString: "[]",
+		},
+		{
+			name:       "non empty",
+			items:      []int{2, 3, 1},
+			wantSize:   3,
+			wantList:   []int{1, 2, 3},
+			wantString: "[1 2 3]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { test(t, tc) })
+	}
+}
+
+func TestFromString(t *testing.T) {
+	type testCase struct {
+		name       string
+		items      []string
+		wantSize   int
+		wantList   []string
+		wantString string
+	}
+
+	test := func(t *testing.T, tc testCase) {
+		s := sets.From(tc.items...)
+		sorted := s.OrderedList()
+
+		assert.Equal(t, s.Size(), tc.wantSize)
+		assert.DeepEqual(t, sorted, tc.wantList)
+		assert.Equal(t, fmt.Sprint(s), tc.wantString)
+	}
+
+	testCases := []testCase{
+		{
+			name:       "non empty",
+			items:      []string{"b", "c", "a"},
+			wantSize:   3,
+			wantList:   []string{"a", "b", "c"},
+			wantString: "[a b c]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { test(t, tc) })
+	}
+}
+
+func TestDifference(t *testing.T) {
+	type testCase struct {
+		name     string
+		s        *sets.Set[int]
+		x        *sets.Set[int]
+		wantList []int
+	}
+
+	test := func(t *testing.T, tc testCase) {
+		result := tc.s.Difference(tc.x)
+		sorted := result.OrderedList()
+
+		assert.DeepEqual(t, sorted, tc.wantList)
+	}
+
+	testCases := []testCase{
+		{
+			name:     "both empty",
+			s:        sets.From[int](),
+			x:        sets.From[int](),
+			wantList: []int{},
+		},
+		{
+			name:     "empty x returns s",
+			s:        sets.From(1, 2, 3),
+			x:        sets.From[int](),
+			wantList: []int{1, 2, 3},
+		},
+		{
+			name:     "nothing in common returns s",
+			s:        sets.From(1, 2, 3),
+			x:        sets.From(4, 5),
+			wantList: []int{1, 2, 3},
+		},
+		{
+			name:     "one in common",
+			s:        sets.From(1, 2, 3),
+			x:        sets.From(4, 2),
+			wantList: []int{1, 3},
+		},
+		{
+			name:     "all in common returns empty set",
+			s:        sets.From(1, 2, 3),
+			x:        sets.From(1, 2, 3, 12),
+			wantList: []int{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { test(t, tc) })
+	}
+}


### PR DESCRIPTION
All the ones I could find where clumsy to use, I was quite surprised.

Hope that Go will soon gain a sets package in the stdlib so that we can get rid
of this one.

I split this from the current branch I am working on because it is self-contained, but to
understand why I implemented only this partial API you have to wait to see the next PR.

I have to say that generics and type constraints are good stuff!

PCI-2561