### PR TITLE
Chat: understand user intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.notify_on_states`. Default (as before this tunable): [`abort`, `error`, `failure`].
+- Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.chat_notify_on_states`. Default (as before this tunable): [`abort`, `error`, `failure`].
 - Google Chat: enrich cogito logging with human-readable information about the chat space.
 - Google Chat: allow to specify a different chat space/webhook during put (see `params.gchat_webhook`).
 - Google Chat: allow to specify a custom chat message, overriding the default build summary (see `params.chat_message`).

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
 - `context_prefix`: The prefix for the GitHub Commit status API "context" (see section [Effects on GitHub](#effects-on-github)). If present, the context will be `context_prefix/job_name`. Default: empty. See also the optional `context` in the [put step](#the-put-step).
 - `gchat_webhook`. Default: empty. URL of a [Google Chat webhook].
     A notification about the build status will be sent to the associated chat space, using a thread key composed by the pipeline name and commit hash (since v0.7.0).
-    See also: `notify_on_states` and section [Effects on Google Chat](#effects-on-google-chat).
-- `notify_on_states`. Default: [`abort`, `error`, `failure`]. The build states that will cause a chat notification. One or more of [`abort`, `error`, `failure`, `pending`, `success`].
+    See also: `chat_notify_on_states` and section [Effects on Google Chat](#effects-on-google-chat).
+- `chat_notify_on_states`. Default: [`abort`, `error`, `failure`]. The build states that will cause a chat notification. One or more of [`abort`, `error`, `failure`, `pending`, `success`].
   See section [Build states mapping](#build-states-mapping).
 - `log_level`: The log level (one of `debug`, `info`, `warn`, `error`, `silent`). Default: `info`.
 - `log_url`. **DEPRECATED, no-op, will be removed** A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < 7.

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ If the `source` block has the optional key `gchat_webhook`, then it will also se
 ## Optional params for chat
 
 - `gchat_webhook`: If present, overrides `source.gchat_webhook`. Default: empty, thus the same as `source.gchat_webhook`. This allows to use the same Cogito resource for multiple chat spaces. 
-- `chat_message`: Custom chat message; overrides the build summary. Default: empty.
-- `chat_message_file`: Path to file containing a custom chat message; overrides the build summary. Appended to `chat_message`. Default: empty.
+- `chat_message`: Custom chat message; overrides the build summary. Default: empty. If present, the chat message will be sent, no matter the value of `source.chat_notify_on_states`.
+- `chat_message_file`: Path to file containing a custom chat message; overrides the build summary. Appended to `chat_message`. Default: empty. If present, the chat message will be sent, no matter the value of `source.chat_notify_on_states`.
 - `chat_message_append`: (one of: true, false). If true, append the default build summary to the custom `chat_message` and/or `chat_message_file`. Default: false.
 
 ## Note on the put inputs

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -36,7 +36,7 @@ func (sink GoogleChatSink) Send() error {
 	}
 
 	state := sink.Request.Params.State
-	if !shouldSendToChat(state, sink.Request.Source.NotifyOnStates) {
+	if !shouldSendToChat(state, sink.Request.Source.ChatNotifyOnStates) {
 		sink.Log.Debug("not sending to chat",
 			"reason", "state not in enabled states", "state", state)
 		return nil

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -36,9 +36,9 @@ func (sink GoogleChatSink) Send() error {
 	}
 
 	state := sink.Request.Params.State
-	if !shouldSendToChat(state, sink.Request.Source.ChatNotifyOnStates) {
+	if !shouldSendToChat(sink.Request) {
 		sink.Log.Debug("not sending to chat",
-			"reason", "state not in enabled states", "state", state)
+			"reason", "state not in configured states", "state", state)
 		return nil
 	}
 
@@ -62,9 +62,12 @@ func (sink GoogleChatSink) Send() error {
 }
 
 // shouldSendToChat returns true if the state is configured to do so.
-func shouldSendToChat(state BuildState, notifyOnStates []BuildState) bool {
-	for _, x := range notifyOnStates {
-		if state == x {
+func shouldSendToChat(request PutRequest) bool {
+	if request.Params.ChatMessage != "" || request.Params.ChatMessageFile != "" {
+		return true
+	}
+	for _, x := range request.Source.ChatNotifyOnStates {
+		if request.Params.State == x {
 			return true
 		}
 	}

--- a/cogito/gchatsink_private_test.go
+++ b/cogito/gchatsink_private_test.go
@@ -17,7 +17,11 @@ func TestShouldSendToChatDefaultConfig(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		assert.Equal(t, shouldSendToChat(tc.state, defaultNotifyStates), tc.want)
+		request := PutRequest{}
+		request.Source.ChatNotifyOnStates = defaultNotifyStates
+		request.Params.State = tc.state
+
+		assert.Equal(t, shouldSendToChat(request), tc.want)
 	}
 
 	testCases := []testCase{
@@ -39,10 +43,12 @@ func TestShouldSendToChatCustomConfig(t *testing.T) {
 		want  bool
 	}
 
-	baseNotifyStates := []BuildState{StatePending, StateSuccess}
-
 	test := func(t *testing.T, tc testCase) {
-		assert.Equal(t, shouldSendToChat(tc.state, baseNotifyStates), tc.want)
+		request := PutRequest{}
+		request.Source.ChatNotifyOnStates = []BuildState{StatePending, StateSuccess}
+		request.Params.State = tc.state
+
+		assert.Equal(t, shouldSendToChat(request), tc.want)
 	}
 
 	testCases := []testCase{

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -62,25 +62,25 @@ type Source struct {
 	//
 	// Optional
 	//
-	GChatWebHook   string       `json:"gchat_webhook"` // SENSITIVE
-	LogLevel       string       `json:"log_level"`
-	LogUrl         string       `json:"log_url"` // DEPRECATED
-	ContextPrefix  string       `json:"context_prefix"`
-	NotifyOnStates []BuildState `json:"notify_on_states"`
+	GChatWebHook       string       `json:"gchat_webhook"` // SENSITIVE
+	LogLevel           string       `json:"log_level"`
+	LogUrl             string       `json:"log_url"` // DEPRECATED
+	ContextPrefix      string       `json:"context_prefix"`
+	ChatNotifyOnStates []BuildState `json:"chat_notify_on_states"`
 }
 
 // String renders Source, redacting the sensitive fields.
 func (src Source) String() string {
 	var bld strings.Builder
 
-	fmt.Fprintf(&bld, "owner:            %s\n", src.Owner)
-	fmt.Fprintf(&bld, "repo:             %s\n", src.Repo)
-	fmt.Fprintf(&bld, "access_token:     %s\n", redact(src.AccessToken))
-	fmt.Fprintf(&bld, "gchat_webhook:    %s\n", redact(src.GChatWebHook))
-	fmt.Fprintf(&bld, "log_level:        %s\n", src.LogLevel)
-	fmt.Fprintf(&bld, "context_prefix:   %s\n", src.ContextPrefix)
+	fmt.Fprintf(&bld, "owner:                 %s\n", src.Owner)
+	fmt.Fprintf(&bld, "repo:                  %s\n", src.Repo)
+	fmt.Fprintf(&bld, "access_token:          %s\n", redact(src.AccessToken))
+	fmt.Fprintf(&bld, "gchat_webhook:         %s\n", redact(src.GChatWebHook))
+	fmt.Fprintf(&bld, "log_level:             %s\n", src.LogLevel)
+	fmt.Fprintf(&bld, "context_prefix:        %s\n", src.ContextPrefix)
 	// Last one: no newline.
-	fmt.Fprintf(&bld, "notify_on_states: %s", src.NotifyOnStates)
+	fmt.Fprintf(&bld, "chat_notify_on_states: %s", src.ChatNotifyOnStates)
 
 	return bld.String()
 }
@@ -154,8 +154,8 @@ func (src *Source) Validate() error {
 	//
 	// Apply defaults.
 	//
-	if len(src.NotifyOnStates) == 0 {
-		src.NotifyOnStates = defaultNotifyStates
+	if len(src.ChatNotifyOnStates) == 0 {
+		src.ChatNotifyOnStates = defaultNotifyStates
 	}
 
 	return nil

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -215,40 +215,40 @@ func TestSourceParseRawFailure(t *testing.T) {
 
 func TestSourcePrintLogRedaction(t *testing.T) {
 	source := cogito.Source{
-		Owner:          "the-owner",
-		Repo:           "the-repo",
-		AccessToken:    "sensitive-the-access-token",
-		GChatWebHook:   "sensitive-gchat-webhook",
-		LogLevel:       "debug",
-		ContextPrefix:  "the-prefix",
-		NotifyOnStates: []cogito.BuildState{cogito.StateSuccess, cogito.StateFailure},
+		Owner:              "the-owner",
+		Repo:               "the-repo",
+		AccessToken:        "sensitive-the-access-token",
+		GChatWebHook:       "sensitive-gchat-webhook",
+		LogLevel:           "debug",
+		ContextPrefix:      "the-prefix",
+		ChatNotifyOnStates: []cogito.BuildState{cogito.StateSuccess, cogito.StateFailure},
 	}
 
 	t.Run("fmt.Print redacts fields", func(t *testing.T) {
-		want := `owner:            the-owner
-repo:             the-repo
-access_token:     ***REDACTED***
-gchat_webhook:    ***REDACTED***
-log_level:        debug
-context_prefix:   the-prefix
-notify_on_states: [success failure]`
+		want := `owner:                 the-owner
+repo:                  the-repo
+access_token:          ***REDACTED***
+gchat_webhook:         ***REDACTED***
+log_level:             debug
+context_prefix:        the-prefix
+chat_notify_on_states: [success failure]`
 
 		have := fmt.Sprint(source)
 
 		assert.Equal(t, have, want)
 	})
-
+	// Trailing spaces here are needed.
 	t.Run("empty fields are not marked as redacted", func(t *testing.T) {
 		input := cogito.Source{
 			Owner: "the-owner",
 		}
-		want := `owner:            the-owner
-repo:             
-access_token:     
-gchat_webhook:    
-log_level:        
-context_prefix:   
-notify_on_states: []`
+		want := `owner:                 the-owner
+repo:                  
+access_token:          
+gchat_webhook:         
+log_level:             
+context_prefix:        
+chat_notify_on_states: []`
 
 		have := fmt.Sprint(input)
 
@@ -262,8 +262,8 @@ notify_on_states: []`
 		log.Info("log test", "source", source)
 		have := logBuf.String()
 
-		assert.Assert(t, cmp.Contains(have, "| access_token:     ***REDACTED***"))
-		assert.Assert(t, cmp.Contains(have, "| gchat_webhook:    ***REDACTED***"))
+		assert.Assert(t, cmp.Contains(have, "| access_token:          ***REDACTED***"))
+		assert.Assert(t, cmp.Contains(have, "| gchat_webhook:         ***REDACTED***"))
 		assert.Assert(t, !strings.Contains(have, "sensitive"))
 	})
 }

--- a/pipelines/cogito-acceptance.yml
+++ b/pipelines/cogito-acceptance.yml
@@ -27,7 +27,7 @@ resources:
       repo: ((repo-name))
       access_token: ((oauth-personal-access-token))
       gchat_webhook: ((gchat_webhook))
-      notify_on_states:  [abort, error, failure, pending, success]
+      chat_notify_on_states:  [abort, error, failure, pending, success]
 
   - name: target-repo.git
     type: git

--- a/pipelines/cogito-acceptance.yml
+++ b/pipelines/cogito-acceptance.yml
@@ -27,7 +27,6 @@ resources:
       repo: ((repo-name))
       access_token: ((oauth-personal-access-token))
       gchat_webhook: ((gchat_webhook))
-      chat_notify_on_states:  [abort, error, failure, pending, success]
 
   - name: target-repo.git
     type: git

--- a/pipelines/cogito.yml
+++ b/pipelines/cogito.yml
@@ -81,7 +81,7 @@ resources:
     access_token: ((oauth-personal-access-token))
     gchat_webhook: ((gchat_webhook))
     # These two states make sense only for testing the resource itself...
-    notify_on_states: [pending, success]
+    chat_notify_on_states: [pending, success]
 
 - name: repo.git
   type: git


### PR DESCRIPTION
This fixes the limitation I mentioned this morning in the standup, that @sambarluc and myself discovered in a test pipeline with the previous release candidate.

Before this change, if on a specific put the user wanted to send a notification
message, for example:
```yaml
    - put: cogito
      inputs: [repo.git, app]
      params:
        state: success
        chat_message: "Perftracker registration of X"
```
He would be forced to actually make the pipeline spammy by adding state
`success` to `source.chat_notify_on_states`.

To solve this, we had two options:

1. Add `put.params.chat_notify_on_states`, but this would look ugly:
```yaml
    - put: cogito
      inputs: [repo.git, app]
      params:
        state: success
        chat_notify_on_states: [success]        <== well it is obvious, no?
        chat_message: "Perftracker registration of X"
```
2. Understand what the user wants: it is obvious that at least one of
chat_message or chat_message_file is set, then the user wants to send the chat
message in this specific put. Note the specific == NON in a job on_xxx handler.

In this PR we implement with option 2.