### PR TITLE
chat: append the build summary by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.8.1] - UNRELEASED
 
+This release allows to use cogito for all chat notifications where previously one would have needed a mix of cogito and concourse-hangouts-resource.
+
 ### Added
 
-- Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.chat_notify_on_states`. Default (as before this tunable): [`abort`, `error`, `failure`].
+- Google Chat: allow selecting which states trigger a notification to the chat, via configuration `source.chat_notify_on_states`. Default (as before this tunable): `[abort, error, failure]`.
 - Google Chat: enrich cogito logging with human-readable information about the chat space.
-- Google Chat: allow to specify a different chat space/webhook during put (see `params.gchat_webhook`).
-- Google Chat: allow to specify a custom chat message, overriding the default build summary (see `params.chat_message`).
-- Google Chat: when passing a custom message or a custom message file, choose whether to append to it the default build summary or not (see `params.chat_message_append`).
-- Google Chat: allow to specify a file containing a custom chat message (see `params.chat_message_file`).
+- Google Chat: allow to specify a different chat space/webhook during put (see `put.params.gchat_webhook`).
+- Google Chat: allow to specify a custom chat message, (see `params.chat_message`).
+- Google Chat: allow to specify a file containing a custom chat message (see `put.params.chat_message_file`).
+- Google Chat: when passing a custom message or a custom message file, choose whether to append to it the default build summary or not (see `source.chat_append_summary`, `put.params.chat_append_summary`). Default: `true`.
 
 ## [v0.8.0] - 2022-08-11
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
   Default: `[abort, error, failure]`.\
   See also: section [Build states mapping](#build-states-mapping).
 
+- `chat_append_summary`\
+  One of: `true`, `false`. If `true`, append the default build summary to the custom `put.params.chat_message` and/or `put.params.chat_message_file`.\
+  Default: `true`.\
+  See also: the default build summary in [Effects on Google Chat](#effects-on-google-chat).
+
 - `log_level`:\
   The log level (one of `debug`, `info`, `warn`, `error`, `silent`).\
   Default: `info`.
@@ -240,9 +245,9 @@ If the `source` block has the optional key `gchat_webhook`, then it will also se
   Path to file containing a custom chat message; overrides the build summary. Appended to `chat_message`. Its presence is enough for the chat message to be sent, overriding `source.chat_notify_on_states`.\
   Default: empty.
 
-- `chat_message_append`\
-  One of: `true`, `false`. If `true`, append the default build summary to the custom `chat_message` and/or `chat_message_file`.\
-  Default: false.
+- `chat_append_summary`\
+  Overrides `source.chat_append_summary`.  
+  Default: `source.chat_append_summary`.
 
 ## Note on the put inputs
 

--- a/README.md
+++ b/README.md
@@ -160,20 +160,39 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
 
 ## Required keys
 
-- `owner`: The GitHub user or organization.
-- `repo`: The GitHub repository name.
-- `access_token`: The OAuth access token. See section [GitHub OAuth token](#github-oauth-token).
+- `owner`\
+  The GitHub user or organization.
+
+- `repo`\
+  The GitHub repository name.
+
+- `access_token`\
+  The OAuth access token.\
+  See also: section [GitHub OAuth token](#github-oauth-token).
 
 ## Optional keys
 
-- `context_prefix`: The prefix for the GitHub Commit status API "context" (see section [Effects on GitHub](#effects-on-github)). If present, the context will be `context_prefix/job_name`. Default: empty. See also the optional `context` in the [put step](#the-put-step).
-- `gchat_webhook`. Default: empty. URL of a [Google Chat webhook].
-    A notification about the build status will be sent to the associated chat space, using a thread key composed by the pipeline name and commit hash (since v0.7.0).
-    See also: `chat_notify_on_states` and section [Effects on Google Chat](#effects-on-google-chat).
-- `chat_notify_on_states`. Default: [`abort`, `error`, `failure`]. The build states that will cause a chat notification. One or more of [`abort`, `error`, `failure`, `pending`, `success`].
-  See section [Build states mapping](#build-states-mapping).
-- `log_level`: The log level (one of `debug`, `info`, `warn`, `error`, `silent`). Default: `info`.
-- `log_url`. **DEPRECATED, no-op, will be removed** A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < 7.
+- `context_prefix`\
+  The prefix for the GitHub Commit status API "context" (see section [Effects on GitHub](#effects-on-github)). If present, the context will be set as `context_prefix/job_name`.\
+  Default: empty.\
+  See also: the optional `context` in the [put step](#the-put-step).
+
+- `gchat_webhook`\
+  URL of a [Google Chat webhook]. A notification about the build status will be sent to the associated chat space, using a thread key composed by the pipeline name and commit hash.\
+  Default: empty.\
+  See also: `chat_notify_on_states` and section [Effects on Google Chat](#effects-on-google-chat).
+
+- `chat_notify_on_states`\
+  The build states that will cause a chat notification. One or more of `abort`, `error`, `failure`, `pending`, `success`.\
+  Default: `[abort, error, failure]`.\
+  See also: section [Build states mapping](#build-states-mapping).
+
+- `log_level`:\
+  The log level (one of `debug`, `info`, `warn`, `error`, `silent`).\
+  Default: `info`.
+
+- `log_url`. **DEPRECATED, no-op, will be removed**\
+  A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < v7.x
 
 ## Suggestions
 
@@ -196,18 +215,34 @@ If the `source` block has the optional key `gchat_webhook`, then it will also se
 
 ## Required params
 
-- `state`: The state to set. One of `error`, `failure`, `pending`, `success`, `abort`. Subject to the mapping explained in section [Effects](#effects).
+- `state`\
+  The state to set. One of `error`, `failure`, `pending`, `success`, `abort`.\
+  See also: the mapping explained in section [Effects](#effects).
 
 ## Optional params for GitHub commit status
 
-- `context`: The value of the non-prefix part of the GitHub Commit status API "context" (see section [Effects on GitHub](#effects-on-github)). Default: the job name. See also the optional `context_prefix` in the [source configuration](#source-configuration).
+- `context`\
+  The value of the non-prefix part of the GitHub Commit status API "context"\
+  Default: the job name.\
+  See also: [Effects on GitHub](#effects-on-github), `source.context_prefix`.
 
 ## Optional params for chat
 
-- `gchat_webhook`: If present, overrides `source.gchat_webhook`. Default: empty, thus the same as `source.gchat_webhook`. This allows to use the same Cogito resource for multiple chat spaces. 
-- `chat_message`: Custom chat message; overrides the build summary. Default: empty. If present, the chat message will be sent, no matter the value of `source.chat_notify_on_states`.
-- `chat_message_file`: Path to file containing a custom chat message; overrides the build summary. Appended to `chat_message`. Default: empty. If present, the chat message will be sent, no matter the value of `source.chat_notify_on_states`.
-- `chat_message_append`: (one of: true, false). If true, append the default build summary to the custom `chat_message` and/or `chat_message_file`. Default: false.
+- `gchat_webhook`\
+  If present, overrides `source.gchat_webhook`. This allows to use the same Cogito resource for multiple chat spaces.\
+  Default: `source.gchat_webhook`. 
+
+- `chat_message`\
+  Custom chat message; overrides the build summary. Its presence is enough for the chat message to be sent, overriding `source.chat_notify_on_states`.\
+  Default: empty.
+
+- `chat_message_file`\
+  Path to file containing a custom chat message; overrides the build summary. Appended to `chat_message`. Its presence is enough for the chat message to be sent, overriding `source.chat_notify_on_states`.\
+  Default: empty.
+
+- `chat_message_append`\
+  One of: `true`, `false`. If `true`, append the default build summary to the custom `chat_message` and/or `chat_message_file`.\
+  Default: false.
 
 ## Note on the put inputs
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,13 +119,6 @@ tasks:
         # stderr for logging.
         sh: echo '{{.INPUT}}' | ./bin/check 2>&1 1>/dev/null
 
-  test:acceptance:
-    desc: Run the Cogito acceptance tests. Needs a running Concourse.
-    cmds:
-      - task: test:acceptance:set-pipeline
-      - task: test:acceptance:chat-message-file
-      - task: test:acceptance:chat-message-append
-
   fly-login:
     desc: Performs a fly login in the target to be used in the acceptance tests.
     cmds:
@@ -146,26 +139,47 @@ tasks:
         -y gchat_webhook=$(gopass show cogito/test_gchat_webhook)
       - fly -t cogito unpause-pipeline -p {{.PIPELINE}}
     vars:
-      PIPELINE: cogito-acceptance-{{.BRANCH}}
+      PIPELINE: cogito-acceptance---{{.BRANCH}}
 
   trigger-job:
     cmds:
       - fly -t cogito trigger-job -j {{.PIPELINE}}/{{.JOB}} -w
     vars:
-      PIPELINE: cogito-acceptance-{{.BRANCH}}
+      PIPELINE: cogito-acceptance---{{.BRANCH}}
       JOB: '{{.JOB}}'
 
-  test:acceptance:chat-message-file:
+  test:acceptance:
+    desc: Run the Cogito acceptance tests. Needs a running Concourse.
+    cmds:
+      - task: test:acceptance:set-pipeline
+      - task: test:acceptance:chat-only-summary
+      - task: test:acceptance:chat-message-default
+      - task: test:acceptance:chat-message-no-summary
+      - task: test:acceptance:chat-message-file-default
+
+  test:acceptance:chat-only-summary:
+    desc: Run a pipeline job to test default chat
+    cmds:
+      - task: trigger-job
+        vars: {JOB: chat-only-summary}
+
+  test:acceptance:chat-message-default:
+    desc: Run a pipeline job to test chat_message
+    cmds:
+      - task: trigger-job
+        vars: {JOB: chat-message-default}
+
+  test:acceptance:chat-message-no-summary:
+    desc: Run a pipeline job to test chat_message and chat_append_summary
+    cmds:
+      - task: trigger-job
+        vars: {JOB: chat-message-no-summary}
+
+  test:acceptance:chat-message-file-default:
     desc: Run a pipeline job to test chat_message_file
     cmds:
       - task: trigger-job
-        vars: {JOB: chat-message-file}
-
-  test:acceptance:chat-message-append:
-    desc: Run a pipeline job to test chat_message_append
-    cmds:
-      - task: trigger-job
-        vars: {JOB: chat-message-append}
+        vars: {JOB: chat-message-file-default}
 
   browser:
     desc: "Show code coverage in browser (usage: task test:<subtarget> browser)"

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -91,7 +91,7 @@ func prepareChatMessage(inputDir fs.FS, request PutRequest, gitRef string,
 		parts = append(parts, string(contents))
 	}
 
-	if len(parts) == 0 || (len(parts) > 0 && params.ChatMessageAppend) {
+	if len(parts) == 0 || (len(parts) > 0 && params.ChatAppendSummary) {
 		parts = append(
 			parts,
 			gChatBuildSummaryText(gitRef, params.State, request.Source, request.Env))

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -191,7 +191,7 @@ func TestSourceParseRawFailure(t *testing.T) {
 {
   "owner": 123
 }`,
-			wantErr: `json: cannot unmarshal number into Go struct field Source.owner of type string`,
+			wantErr: `json: cannot unmarshal number into Go struct field source.owner of type string`,
 		},
 		{
 			name: "Unknown fields are caught automatically by the JSON decoder",
@@ -221,6 +221,7 @@ func TestSourcePrintLogRedaction(t *testing.T) {
 		GChatWebHook:       "sensitive-gchat-webhook",
 		LogLevel:           "debug",
 		ContextPrefix:      "the-prefix",
+		ChatAppendSummary:  true,
 		ChatNotifyOnStates: []cogito.BuildState{cogito.StateSuccess, cogito.StateFailure},
 	}
 
@@ -231,6 +232,7 @@ access_token:          ***REDACTED***
 gchat_webhook:         ***REDACTED***
 log_level:             debug
 context_prefix:        the-prefix
+chat_append_summary:   true
 chat_notify_on_states: [success failure]`
 
 		have := fmt.Sprint(source)
@@ -248,6 +250,7 @@ access_token:
 gchat_webhook:         
 log_level:             
 context_prefix:        
+chat_append_summary:   false
 chat_notify_on_states: []`
 
 		have := fmt.Sprint(input)
@@ -282,7 +285,7 @@ func TestPutParamsPrintLogRedaction(t *testing.T) {
 context:             johnny
 chat_message:        stecchino
 chat_message_file:   dir/msg.txt
-chat_message_append: false
+chat_append_summary: false
 gchat_webhook:       ***REDACTED***`
 
 		have := fmt.Sprint(params)
@@ -299,7 +302,7 @@ gchat_webhook:       ***REDACTED***`
 context:             
 chat_message:        
 chat_message_file:   
-chat_message_append: false
+chat_append_summary: false
 gchat_webhook:       `
 
 		have := fmt.Sprint(input)

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -96,7 +96,6 @@ func NewPutter(ghAPI string, log hclog.Logger) *ProdPutter {
 
 func (putter *ProdPutter) LoadConfiguration(in io.Reader, args []string) error {
 	dec := json.NewDecoder(in)
-	dec.DisallowUnknownFields()
 	if err := dec.Decode(&putter.Request); err != nil {
 		return fmt.Errorf("put: parsing request: %s", err)
 	}

--- a/pipelines/cogito-acceptance.yml
+++ b/pipelines/cogito-acceptance.yml
@@ -28,6 +28,17 @@ resources:
       access_token: ((oauth-personal-access-token))
       gchat_webhook: ((gchat_webhook))
 
+  - name: cogito-notify-always
+    type: cogito
+    check_every: never
+    source:
+      log_level: debug
+      owner: ((github-owner))
+      repo: ((repo-name))
+      access_token: ((oauth-personal-access-token))
+      gchat_webhook: ((gchat_webhook))
+      chat_notify_on_states: [abort, error, failure, pending, success]
+
   - name: target-repo.git
     type: git
     source:
@@ -44,7 +55,15 @@ resources:
 
 jobs:
 
-  - name: chat-message-append
+  - name: chat-only-summary
+    plan:
+      - get: target-repo.git
+      - put: cogito-notify-always
+        inputs: [target-repo.git]
+        params:
+          state: success
+
+  - name: chat-message-default
     plan:
       - get: target-repo.git
       - put: cogito
@@ -52,9 +71,18 @@ jobs:
         params:
           state: success
           chat_message: "This is the custom chat message. Below, the default build summary:"
-          chat_message_append: true
 
-  - name: chat-message-file
+  - name: chat-message-no-summary
+    plan:
+      - get: target-repo.git
+      - put: cogito
+        inputs: [target-repo.git]
+        params:
+          state: success
+          chat_message: "This is the custom chat message. No summary below."
+          chat_append_summary: false
+
+  - name: chat-message-file-default
     plan:
       - get: cogito-repo.git
       - get: target-repo.git

--- a/pipelines/cogito.yml
+++ b/pipelines/cogito.yml
@@ -169,4 +169,3 @@ jobs:
           state: success
           # Append the default build summary to the custom message.
           chat_message: "appending hello from kitty-jo"
-          chat_message_append: true


### PR DESCRIPTION
chat: append the build summary by default

Configuration:

- `source.chat_append_build_summary` (default: `true`)
- `put.params.chat_append_build_summary` (default: `source.chat_append_build_summary`)

Once this is merged, we can release :-)

A good way to get an overview is to look at the acceptance pipeline: pipelines/cogito-acceptance.yml

PCI-2663
