### PR TITLE
peek at the log level and simplify object construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.2] - UNRELEASED
+
+### Minor breaking change
+
+- `source.log_level`. If you were previously silencing the logging with level `silent`, it will now be interpreted as invalid and automatically remapped to `info`. If you really want no logging, the log level to use is `off`.
+  Note that there is no reason to disable logging, since it is not visible in the build log in the UI, and the default of `info` helps to, for example, know which version of cogito is being used. 
+
 ## [v0.8.1] - 2022-09-07
 
 This release allows to use cogito for all chat notifications where previously one would have needed a mix of cogito and concourse-hangouts-resource.
@@ -203,3 +210,5 @@ This release allows to use cogito for all chat notifications where previously on
 [v0.7.0]: https://github.com/Pix4D/cogito/releases/tag/v0.7.0
 [v0.7.1]: https://github.com/Pix4D/cogito/releases/tag/v0.7.1
 [v0.8.0]: https://github.com/Pix4D/cogito/releases/tag/v0.8.0
+[v0.8.1]: https://github.com/Pix4D/cogito/releases/tag/v0.8.1
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,7 +374,7 @@ A release is performed by the GitHub Action CI, triggered by a git tag of the fo
 - Prepare the PR to also contain an updated CHANGELOG.
 - Merge the PR to master.
 - git checkout master && git pull
-- Create and then push a git tag.
+- Create and then push a git tag (git tag -a -m '' v0.8.0 && git push origin v0.8.0)
 - Double-check that the GitHub Action CI issues the release and that the new image appeared on [dockerhub](https://hub.docker.com/repository/docker/pix4d/cogito).
 
 # License

--- a/cmd/cogito/main.go
+++ b/cmd/cogito/main.go
@@ -71,7 +71,7 @@ func mainErr(in io.Reader, out io.Writer, logOut io.Writer, args []string) error
 
 // peekLogLevel decodes 'input' as JSON and looks for key source.log_level. If 'input'
 // is not JSON, peekLogLevel will return an error. If 'input' is JSON but does not
-// contain key source.log_level, peekLogLevel returns the empty string.
+// contain key source.log_level, peekLogLevel returns "info" as default value.
 //
 // Rationale: depending on the Concourse step we are invoked for, the JSON object we get
 // from stdin is different, but it always contains a struct with name "source", thus we
@@ -83,7 +83,7 @@ func peekLogLevel(input []byte) (string, error) {
 		} `json:"source"`
 	}
 	var peek Peek
-	peek.Source.LogLevel = "info"
+	peek.Source.LogLevel = "info" // default value
 	if err := json.Unmarshal(input, &peek); err != nil {
 		return "", fmt.Errorf("peeking into JSON for log_level: %s", err)
 	}

--- a/cmd/cogito/main.go
+++ b/cmd/cogito/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/Pix4D/cogito/cogito"
 	"github.com/Pix4D/cogito/github"
+	"github.com/Pix4D/cogito/sets"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -18,15 +20,30 @@ func main() {
 	// - stdin, stdout and command-line arguments for the protocol itself
 	// - stderr for logging
 	// See: https://concourse-ci.org/implementing-resource-types.html
-	if err := run(os.Stdin, os.Stdout, os.Stderr, os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+	if err := mainErr(os.Stdin, os.Stdout, os.Stderr, os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "cogito: error: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(in io.Reader, out io.Writer, logOut io.Writer, args []string) error {
+func mainErr(in io.Reader, out io.Writer, logOut io.Writer, args []string) error {
+	cmd := path.Base(args[0])
+	validCmds := sets.From("check", "in", "out")
+	if !validCmds.Contains(cmd) {
+		return fmt.Errorf("invoked as '%s'; want: one of %v", cmd, validCmds)
+	}
+
+	input, err := io.ReadAll(in)
+	if err != nil {
+		return fmt.Errorf("reading stdin: %s", err)
+	}
+	logLevel, err := peekLogLevel(input)
+	if err != nil {
+		return err
+	}
 	log := hclog.New(&hclog.LoggerOptions{
 		Name:        "cogito",
+		Level:       hclog.LevelFromString(logLevel),
 		Output:      logOut,
 		DisableTime: true,
 	})
@@ -39,18 +56,37 @@ func run(in io.Reader, out io.Writer, logOut io.Writer, args []string) error {
 		ghAPI = github.API
 	}
 
-	command := path.Base(args[0])
-	switch command {
+	switch cmd {
 	case "check":
-		return cogito.Check(log, in, out, args[1:])
+		return cogito.Check(log, input, out, args[1:])
 	case "in":
-		return cogito.Get(log, in, out, args[1:])
+		return cogito.Get(log, input, out, args[1:])
 	case "out":
 		putter := cogito.NewPutter(ghAPI, log)
-		return cogito.Put(log, in, out, args[1:], putter)
+		return cogito.Put(log, input, out, args[1:], putter)
 	default:
-		return fmt.Errorf(
-			"cogito: unexpected invocation as '%s'; want: one of 'check', 'in', 'out'; (command-line: %s)",
-			command, args)
+		return fmt.Errorf("cli wiring error; please report")
 	}
+}
+
+// peekLogLevel decodes 'input' as JSON and looks for key source.log_level. If 'input'
+// is not JSON, peekLogLevel will return an error. If 'input' is JSON but does not
+// contain key source.log_level, peekLogLevel returns the empty string.
+//
+// Rationale: depending on the Concourse step we are invoked for, the JSON object we get
+// from stdin is different, but it always contains a struct with name "source", thus we
+// can peek into it to gather the log level as soon as possible.
+func peekLogLevel(input []byte) (string, error) {
+	type Peek struct {
+		Source struct {
+			LogLevel string `json:"log_level"`
+		} `json:"source"`
+	}
+	var peek Peek
+	peek.Source.LogLevel = "info"
+	if err := json.Unmarshal(input, &peek); err != nil {
+		return "", fmt.Errorf("peeking into JSON for log_level: %s", err)
+	}
+
+	return peek.Source.LogLevel, nil
 }

--- a/cogito/check.go
+++ b/cogito/check.go
@@ -26,7 +26,6 @@ func Check(log hclog.Logger, input []byte, out io.Writer, args []string) error {
 	if err != nil {
 		return err
 	}
-	log.SetLevel(hclog.LevelFromString(request.Source.LogLevel))
 	log.Debug("parsed check request",
 		"source", request.Source,
 		"version", request.Version,

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -94,12 +94,6 @@ func TestCheckFailure(t *testing.T) {
 			wantErr: "check: source: missing keys: owner, repo, access_token",
 		},
 		{
-			name:    "validation failure: log",
-			source:  testhelp.MergeStructs(baseSource, cogito.Source{LogLevel: "pippo"}),
-			writer:  io.Discard,
-			wantErr: "check: source: invalid log_level: pippo",
-		},
-		{
 			name:    "write error",
 			source:  baseSource,
 			writer:  &testhelp.FailingWriter{},

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -2,10 +2,8 @@ package cogito_test
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"testing"
-	"testing/iotest"
 
 	"github.com/Pix4D/cogito/cogito"
 	"github.com/Pix4D/cogito/testhelp"
@@ -21,7 +19,7 @@ func TestCheckSuccess(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		in := bytes.NewReader(testhelp.ToJSON(t, tc.request))
+		in := testhelp.ToJSON(t, tc.request)
 		var out bytes.Buffer
 		log := hclog.NewNullLogger()
 
@@ -68,17 +66,13 @@ func TestCheckFailure(t *testing.T) {
 	type testCase struct {
 		name    string
 		source  cogito.Source // will be embedded in cogito.CheckRequest
-		reader  io.Reader     // if set, will override field `source`.
 		writer  io.Writer
 		wantErr string
 	}
 
 	test := func(t *testing.T, tc testCase) {
 		assert.Assert(t, tc.wantErr != "")
-		in := tc.reader
-		if in == nil {
-			in = bytes.NewReader(testhelp.ToJSON(t, cogito.CheckRequest{Source: tc.source}))
-		}
+		in := testhelp.ToJSON(t, cogito.CheckRequest{Source: tc.source})
 		log := hclog.NewNullLogger()
 
 		err := cogito.Check(log, in, tc.writer, nil)
@@ -111,13 +105,6 @@ func TestCheckFailure(t *testing.T) {
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "check: test write error",
 		},
-		{
-			name:    "read error",
-			source:  cogito.Source{},
-			reader:  iotest.ErrReader(errors.New("test read error")),
-			writer:  io.Discard,
-			wantErr: "check: parsing request: test read error",
-		},
 	}
 
 	for _, tc := range testCases {
@@ -125,4 +112,12 @@ func TestCheckFailure(t *testing.T) {
 			test(t, tc)
 		})
 	}
+}
+
+func TestCheckInputFailure(t *testing.T) {
+	log := hclog.NewNullLogger()
+
+	err := cogito.Check(log, nil, io.Discard, nil)
+
+	assert.Error(t, err, "check: parsing request: EOF")
 }

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -103,7 +103,7 @@ func TestCheckFailure(t *testing.T) {
 			name:    "write error",
 			source:  baseSource,
 			writer:  &testhelp.FailingWriter{},
-			wantErr: "check: test write error",
+			wantErr: "check: preparing output: test write error",
 		},
 	}
 

--- a/cogito/get.go
+++ b/cogito/get.go
@@ -33,7 +33,6 @@ func Get(log hclog.Logger, input []byte, out io.Writer, args []string) error {
 	if err != nil {
 		return err
 	}
-	log.SetLevel(hclog.LevelFromString(request.Source.LogLevel))
 	log.Debug("parsed get request",
 		"source", request.Source,
 		"version", request.Version,

--- a/cogito/get.go
+++ b/cogito/get.go
@@ -1,6 +1,7 @@
 package cogito
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,9 +25,12 @@ import (
 // The program must emit a JSON object containing the fetched version, and may emit
 // metadata as a list of key-value pairs.
 // This data is intended for public consumption and will be shown on the build page.
-func Get(log hclog.Logger, in io.Reader, out io.Writer, args []string) error {
+func Get(log hclog.Logger, input []byte, out io.Writer, args []string) error {
 	var request GetRequest
-	dec := json.NewDecoder(in)
+	// Since we also want to enforce the parser to fail if it encounters unknown fields,
+	// we cannot use the customary json.Unmarshal(data, &aux) but we have to go through
+	// a json decoder.
+	dec := json.NewDecoder(bytes.NewReader(input))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&request); err != nil {
 		return fmt.Errorf("get: parsing request: %s", err)

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -117,7 +117,7 @@ func TestGetFailure(t *testing.T) {
 			source:  baseSource,
 			version: cogito.Version{Ref: "dummy"},
 			writer:  &testhelp.FailingWriter{},
-			wantErr: "get: test write error",
+			wantErr: "get: preparing output: test write error",
 		},
 	}
 

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -93,12 +93,6 @@ func TestGetFailure(t *testing.T) {
 			wantErr: "get: source: missing keys: owner, repo, access_token",
 		},
 		{
-			name:    "user validation failure: log_level",
-			source:  testhelp.MergeStructs(baseSource, cogito.Source{LogLevel: "pippo"}),
-			writer:  io.Discard,
-			wantErr: "get: source: invalid log_level: pippo",
-		},
-		{
 			name:    "concourse validation failure: empty version field",
 			source:  baseSource,
 			writer:  io.Discard,

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -2,11 +2,8 @@ package cogito_test
 
 import (
 	"bytes"
-	"errors"
 	"io"
-	"strings"
 	"testing"
-	"testing/iotest"
 
 	"github.com/Pix4D/cogito/cogito"
 	"github.com/Pix4D/cogito/testhelp"
@@ -22,7 +19,7 @@ func TestGetSuccess(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		in := bytes.NewReader(testhelp.ToJSON(t, tc.request))
+		in := testhelp.ToJSON(t, tc.request)
 		var out bytes.Buffer
 		log := hclog.NewNullLogger()
 
@@ -64,21 +61,17 @@ func TestGetFailure(t *testing.T) {
 		args    []string
 		source  cogito.Source  // will be embedded in cogito.GetRequest
 		version cogito.Version // will be embedded in cogito.GetRequest
-		reader  io.Reader      // if set, will override fields source and version above.
 		writer  io.Writer
 		wantErr string
 	}
 
 	test := func(t *testing.T, tc testCase) {
 		assert.Assert(t, tc.wantErr != "")
-		in := tc.reader
-		if in == nil {
-			in = bytes.NewReader(testhelp.ToJSON(t,
-				cogito.GetRequest{
-					Source:  tc.source,
-					Version: tc.version,
-				}))
-		}
+		in := testhelp.ToJSON(t,
+			cogito.GetRequest{
+				Source:  tc.source,
+				Version: tc.version,
+			})
 		log := hclog.NewNullLogger()
 
 		err := cogito.Get(log, in, tc.writer, tc.args)
@@ -126,12 +119,6 @@ func TestGetFailure(t *testing.T) {
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "get: test write error",
 		},
-		{
-			name:    "system read error",
-			reader:  iotest.ErrReader(errors.New("test read error")),
-			writer:  io.Discard,
-			wantErr: "get: parsing request: test read error",
-		},
 	}
 
 	for _, tc := range testCases {
@@ -142,7 +129,7 @@ func TestGetFailure(t *testing.T) {
 }
 
 func TestGetNonEmptyParamsFailure(t *testing.T) {
-	in := strings.NewReader(`
+	in := []byte(`
 {
   "source": {},
   "params": {"pizza": "margherita"}

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -231,29 +231,14 @@ func (src *Source) Validate() error {
 	//
 	// Validate optional fields.
 	//
-
-	// Normally we would leave this validation directly to the logging package, but since
-	// the log level names are part of the Cogito API and predate the removal of ofcourse,
-	// we need to handle the mapping and the error message, to avoid confusing the user.
-	logAdapter := map[string]string{
-		"debug":  "debug",
-		"info":   "info",
-		"warn":   "warn",
-		"error":  "error",
-		"silent": "off", // different
-	}
-	if src.LogLevel != "" {
-		if _, ok := logAdapter[src.LogLevel]; !ok {
-			return fmt.Errorf("source: invalid log_level: %s", src.LogLevel)
-		}
-		src.LogLevel = logAdapter[src.LogLevel]
-	} else {
-		src.LogLevel = "info" // default
-	}
+	// In this case, nothing to validate.
 
 	//
 	// Apply defaults.
 	//
+	if src.LogLevel == "" {
+		src.LogLevel = "info"
+	}
 	if len(src.ChatNotifyOnStates) == 0 {
 		src.ChatNotifyOnStates = defaultNotifyStates
 	}

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -17,6 +17,7 @@ var DummyVersion = Version{Ref: "dummy"}
 
 // CheckRequest contains the JSON object passed on the stdin of the "check" executable
 // (Source and Version) and the build metadata (Env, environment variables).
+// Use [NewCheckRequest] to instantiate.
 //
 // See https://concourse-ci.org/implementing-resource-types.html#resource-check
 type CheckRequest struct {
@@ -26,8 +27,30 @@ type CheckRequest struct {
 	Env     Environment
 }
 
+// NewCheckRequest returns a [CheckRequest] ready to be used.
+func NewCheckRequest(input []byte) (CheckRequest, error) {
+	var request CheckRequest
+	// Since we also want to enforce the parser to fail if it encounters unknown fields,
+	// we cannot use the customary json.Unmarshal(data, &aux) but we have to go through
+	// a json decoder.
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&request); err != nil {
+		return CheckRequest{}, fmt.Errorf("check: parsing request: %s", err)
+	}
+
+	if err := request.Source.Validate(); err != nil {
+		return CheckRequest{}, fmt.Errorf("check: %s", err)
+	}
+
+	request.Env.Fill()
+
+	return request, nil
+}
+
 // GetRequest contains the JSON object passed on the stdin of the "request" executable
 // (Source and Version) and the build metadata (Env, environment variables).
+// Use [NewGetRequest] to instantiate.
 //
 // See https://concourse-ci.org/implementing-resource-types.html#resource-in
 type GetRequest struct {
@@ -39,14 +62,57 @@ type GetRequest struct {
 	Env Environment
 }
 
+// NewGetRequest returns a [GetRequest] ready to be used.
+func NewGetRequest(input []byte) (GetRequest, error) {
+	var request GetRequest
+	// Since we also want to enforce the parser to fail if it encounters unknown fields,
+	// we cannot use the customary json.Unmarshal(data, &aux) but we have to go through
+	// a json decoder.
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&request); err != nil {
+		return GetRequest{}, fmt.Errorf("get: parsing request: %s", err)
+	}
+
+	if err := request.Source.Validate(); err != nil {
+		return GetRequest{}, fmt.Errorf("get: %s", err)
+	}
+
+	request.Env.Fill()
+
+	return request, nil
+}
+
 // PutRequest contains the JSON object passed to the stdin of the "out" executable
 // (Source and Params) and the build metadata (Env, environment variables).
+// Use [NewPutRequest] to instantiate.
 //
 // See https://concourse-ci.org/implementing-resource-types.html#resource-out
 type PutRequest struct {
 	Source Source    `json:"source"`
 	Params PutParams `json:"params"`
 	Env    Environment
+}
+
+// NewPutRequest returns a [PutRequest] ready to be used.
+func NewPutRequest(input []byte) (PutRequest, error) {
+	var request PutRequest
+	// Since we also want to enforce the parser to fail if it encounters unknown fields,
+	// we cannot use the customary json.Unmarshal(data, &aux) but we have to go through
+	// a json decoder.
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&request); err != nil {
+		return PutRequest{}, fmt.Errorf("put: parsing request: %s", err)
+	}
+
+	if err := request.Source.Validate(); err != nil {
+		return PutRequest{}, fmt.Errorf("put: %s", err)
+	}
+
+	request.Env.Fill()
+
+	return request, nil
 }
 
 func (req *PutRequest) UnmarshalJSON(data []byte) error {
@@ -143,41 +209,6 @@ func (src *Source) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ValidateLog validates and applies defaults for the logging configuration of Source.
-//
-// This chicken-and-egg problem is due to the fact that logging configuration is passed
-// too late, at the same time as all the other resource Source configuration, so to give
-// as much debugging information as possible we need to get the log level as soon as
-// possible, also if the Source has other errors. This cannot be simplified, we are
-// working within the limits of the Concourse resource protocol.
-func (src *Source) ValidateLog() error {
-	// Normally we would leave this validation directly to the logging package, but since
-	// the log level names are part of the Cogito API and predate the removal of ofcourse,
-	// we need to handle the mapping and the error message, to avoid confusing the user.
-	logAdapter := map[string]string{
-		"debug":  "debug",
-		"info":   "info",
-		"warn":   "warn",
-		"error":  "error",
-		"silent": "off", // different
-	}
-	if src.LogLevel != "" {
-		if _, ok := logAdapter[src.LogLevel]; !ok {
-			return fmt.Errorf("source: invalid log_level: %s", src.LogLevel)
-		}
-		src.LogLevel = logAdapter[src.LogLevel]
-	}
-
-	//
-	// Apply defaults for logging.
-	//
-	if src.LogLevel == "" {
-		src.LogLevel = "info"
-	}
-
-	return nil
-}
-
 // Validate verifies the Source configuration and applies defaults.
 func (src *Source) Validate() error {
 	//
@@ -198,8 +229,27 @@ func (src *Source) Validate() error {
 	}
 
 	//
-	// Validate optional fields. In this case, nothing to do.
+	// Validate optional fields.
 	//
+
+	// Normally we would leave this validation directly to the logging package, but since
+	// the log level names are part of the Cogito API and predate the removal of ofcourse,
+	// we need to handle the mapping and the error message, to avoid confusing the user.
+	logAdapter := map[string]string{
+		"debug":  "debug",
+		"info":   "info",
+		"warn":   "warn",
+		"error":  "error",
+		"silent": "off", // different
+	}
+	if src.LogLevel != "" {
+		if _, ok := logAdapter[src.LogLevel]; !ok {
+			return fmt.Errorf("source: invalid log_level: %s", src.LogLevel)
+		}
+		src.LogLevel = logAdapter[src.LogLevel]
+	} else {
+		src.LogLevel = "info" // default
+	}
 
 	//
 	// Apply defaults.

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -104,7 +104,6 @@ func (putter *ProdPutter) LoadConfiguration(input []byte, args []string) error {
 		return err
 	}
 	putter.Request = request
-	putter.log.SetLevel(hclog.LevelFromString(request.Source.LogLevel))
 	putter.log.Debug("parsed put request",
 		"source", putter.Request.Source,
 		"params", putter.Request.Params,

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -152,14 +152,6 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 			wantErr:  "put: source: missing keys: owner, repo, access_token",
 		},
 		{
-			name: "source: invalid log_level",
-			putInput: cogito.PutRequest{
-				Source: testhelp.MergeStructs(baseSource, cogito.Source{LogLevel: "pippo"}),
-				Params: baseParams,
-			},
-			wantErr: "put: source: invalid log_level: pippo",
-		},
-		{
 			name: "params: invalid",
 			putInput: cogito.PutRequest{
 				Source: baseSource,

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -1,13 +1,10 @@
 package cogito_test
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"path/filepath"
-	"strings"
 	"testing"
-	"testing/iotest"
 
 	"github.com/Pix4D/cogito/cogito"
 	"github.com/Pix4D/cogito/testhelp"
@@ -38,7 +35,7 @@ type MockPutter struct {
 	sinkers              []cogito.Sinker
 }
 
-func (mp MockPutter) LoadConfiguration(in io.Reader, args []string) error {
+func (mp MockPutter) LoadConfiguration(input []byte, args []string) error {
 	return mp.loadConfigurationErr
 }
 
@@ -123,7 +120,7 @@ func TestPutFailure(t *testing.T) {
 }
 
 func TestPutterLoadConfigurationSuccess(t *testing.T) {
-	in := bytes.NewReader(testhelp.ToJSON(t, basePutRequest))
+	in := testhelp.ToJSON(t, basePutRequest)
 	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, []string{"dummy-dir"})
@@ -140,7 +137,7 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		in := bytes.NewReader(testhelp.ToJSON(t, tc.putInput))
+		in := testhelp.ToJSON(t, tc.putInput)
 		putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
 		err := putter.LoadConfiguration(in, tc.args)
@@ -183,16 +180,8 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 	}
 }
 
-func TestPutterLoadConfigurationSystemFailure(t *testing.T) {
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
-
-	err := putter.LoadConfiguration(iotest.ErrReader(errors.New("test read error")), nil)
-
-	assert.Error(t, err, "put: parsing request: test read error")
-}
-
 func TestPutterLoadConfigurationInvalidParamsFailure(t *testing.T) {
-	in := strings.NewReader(`
+	in := []byte(`
 {
   "source": {},
   "params": {"pizza": "margherita"}


### PR DESCRIPTION
This is one of the cleanups I mentioned at the standup

Better reviewed commit-per-commit because a lot of file overlaps.

TODO

- [x] remove silient/off backward compatibility