### PR TITLE
PCI-2665 Independent chat send add ability to specify sinks (put params)

### DIFF
--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -348,8 +348,9 @@ func (params PutParams) String() string {
 	fmt.Fprintf(&bld, "chat_message:        %s\n", params.ChatMessage)
 	fmt.Fprintf(&bld, "chat_message_file:   %s\n", params.ChatMessageFile)
 	fmt.Fprintf(&bld, "chat_append_summary: %v\n", params.ChatAppendSummary)
+	fmt.Fprintf(&bld, "gchat_webhook:       %s\n", redact(params.GChatWebHook))
 	// Last one: no newline.
-	fmt.Fprintf(&bld, "gchat_webhook:       %s", redact(params.GChatWebHook))
+	fmt.Fprintf(&bld, "sinks:               %s", params.Sinks)
 
 	return bld.String()
 }

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -331,11 +331,12 @@ type PutParams struct {
 	//
 	// Optional
 	//
-	Context           string `json:"context"`
-	ChatMessage       string `json:"chat_message"`
-	ChatMessageFile   string `json:"chat_message_file"`
-	ChatAppendSummary bool   `json:"chat_append_summary"`
-	GChatWebHook      string `json:"gchat_webhook"` // SENSITIVE
+	Context           string   `json:"context"`
+	ChatMessage       string   `json:"chat_message"`
+	ChatMessageFile   string   `json:"chat_message_file"`
+	ChatAppendSummary bool     `json:"chat_append_summary"`
+	GChatWebHook      string   `json:"gchat_webhook"` // SENSITIVE
+	Sinks             []string `json:"sinks"`
 }
 
 // String renders PutParams, redacting the sensitive fields.

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -209,6 +209,7 @@ func TestPutParamsPrintLogRedaction(t *testing.T) {
 		ChatMessage:     "stecchino",
 		ChatMessageFile: "dir/msg.txt",
 		GChatWebHook:    "sensitive-gchat-webhook",
+		Sinks:           []string{"gchat", "github"},
 	}
 
 	t.Run("fmt.Print redacts fields", func(t *testing.T) {
@@ -217,7 +218,8 @@ context:             johnny
 chat_message:        stecchino
 chat_message_file:   dir/msg.txt
 chat_append_summary: false
-gchat_webhook:       ***REDACTED***`
+gchat_webhook:       ***REDACTED***
+sinks:               [gchat github]`
 
 		have := fmt.Sprint(params)
 
@@ -234,7 +236,8 @@ context:
 chat_message:        
 chat_message_file:   
 chat_append_summary: false
-gchat_webhook:       `
+gchat_webhook:       
+sinks:               []`
 
 		have := fmt.Sprint(input)
 

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -16,7 +16,7 @@ type Putter interface {
 	// ProcessInputDir validates and extract the needed information from the "put input".
 	ProcessInputDir() error
 	// Sinks return the list of configured sinks.
-	Sinks() []Sinker
+	Sinks() ([]Sinker, error)
 	// Output emits the version and metadata required by the Concourse protocol.
 	Output(out io.Writer) error
 }
@@ -51,7 +51,11 @@ func Put(log hclog.Logger, input []byte, out io.Writer, args []string, putter Pu
 
 	// We invoke all the sinks and keep going also if some of them return an error.
 	var sinkErrors []error
-	for _, sink := range putter.Sinks() {
+	sinks, err := putter.Sinks()
+	if err != nil {
+		return fmt.Errorf("put: %s", err)
+	}
+	for _, sink := range sinks {
 		if err := sink.Send(); err != nil {
 			sinkErrors = append(sinkErrors, err)
 		}

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -43,8 +43,8 @@ func (mp MockPutter) ProcessInputDir() error {
 	return mp.processInputDirErr
 }
 
-func (mp MockPutter) Sinks() []cogito.Sinker {
-	return mp.sinkers
+func (mp MockPutter) Sinks() ([]cogito.Sinker, error) {
+	return mp.sinkers, nil
 }
 
 func (mp MockPutter) Output(out io.Writer) error {
@@ -249,11 +249,11 @@ func TestPutterProcessInputDirFailure(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{
+		/*{
 			name:     "no input dirs",
 			inputDir: "testdata/empty-dir",
 			wantErr:  "put:inputs: missing directory for GitHub repo: have: [], GitHub: dummy-owner/dummy-repo",
-		},
+		},*/
 		{
 			name:     "two input dirs",
 			inputDir: "testdata/two-dirs",
@@ -309,7 +309,7 @@ func TestPutterProcessInputDirNonExisting(t *testing.T) {
 func TestPutterSinks(t *testing.T) {
 	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
-	sinks := putter.Sinks()
+	sinks, _ := putter.Sinks()
 
 	assert.Assert(t, len(sinks) == 2)
 	_, ok1 := sinks[0].(cogito.GitHubCommitStatusSink)

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -65,8 +65,9 @@ func (putter *ProdPutter) LoadConfiguration(input []byte, args []string) error {
 }
 
 func (putter *ProdPutter) ProcessInputDir() error {
-	// putter.InputDir, corresponding to key "put:inputs:", should contain 1 or 2 dirs.
-	// If it contains one, we support autodiscovery by not requiring to name it, we know
+	// putter.InputDir, corresponding to key "put:inputs:", should contain 0, 1 or 2 dirs.
+	// If it contains one, it could be the git repo or the directory containing the chat message:
+	// in the first case we support autodiscovery by not requiring to name it, we know
 	// that it should be the git repo.
 	// If on the other hand it contains two, one should be the git repo (still nameless)
 	// and the other should be the directory containing the chat_message_file, which is
@@ -105,10 +106,10 @@ func (putter *ProdPutter) ProcessInputDir() error {
 		}
 	}
 
+	// If the size is 0 after removing the directory containing the chat message, this will be a chat only put.
 	if inputDirs.Size() == 0 {
-		return fmt.Errorf(
-			"put:inputs: missing directory for GitHub repo: have: %v, GitHub: %s/%s",
-			collected, source.Owner, source.Repo)
+		putter.log.Debug("No GitHub repositories in inputs, Cogito will only send to chat")
+		return nil
 	} else if inputDirs.Size() > 1 {
 		return fmt.Errorf(
 			"put:inputs: want only directory for GitHub repo: have: %v, GitHub: %s/%s",


### PR DESCRIPTION
Part of: [PCI-2665](https://pix4dbug.atlassian.net/browse/PCI-2665)

This is the first part of the new feature, it's developed around `put.params`. The next PR will address the `source` resource configuration and it will complete the tests. **Note** also that the README will be updated accordingly in a separate PR.

### What is this PR introducing? 
Basically it adds a parameter `sinks` that can be specified in a `put` step. This new parameter is expected as a slice of strings and if nothing is specified it behaviors as before defaulting to all supported sinks. Currently only 2 are supported: `github` and `gchat`.

Example:

`put` step will only send to gchat, no Github status involved. 
```yaml
plan:
      - get: the-repo
        trigger: true
      - put: gchat
        params: 
         state: pending
         sinks: ["gchat"]
      ...
```

Best review commity by commit.

### Todos

- [ ] Update documentation (separate PR)
- [ ] Add and update current tests ( next PR)
- [ ] Add sinks in source configuration ( again, added in next PR)