### PR TITLE
Pci 2665 independent chat send add sinks to source

### DIFF
--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -99,10 +99,10 @@ func TestCheckFailure(t *testing.T) {
 		{
 			name: "validation failure: wrong sink key",
 			source: cogito.Source{
-				Sinks: []string{"slack", "gchat"},
+				Sinks: []string{"ghost", "gchat"},
 			},
 			writer:  io.Discard,
-			wantErr: "check: source: invalid sink: [slack]. Supported sinks: [gchat github]",
+			wantErr: "check: source: invalid sink(s): [ghost]. Supported sinks: [gchat github]",
 		},
 		{
 			name:    "write error",

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -53,6 +53,16 @@ func TestCheckSuccess(t *testing.T) {
 			},
 			wantOut: []cogito.Version{{Ref: "dummy"}},
 		},
+		{
+			name: "first request (Concourse omits the version field) gchat only",
+			request: cogito.CheckRequest{
+				Source: cogito.Source{
+					Sinks:        []string{"gchat"},
+					GChatWebHook: "https://dummy-webhook",
+				},
+			},
+			wantOut: []cogito.Version{{Ref: "dummy"}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -88,10 +98,18 @@ func TestCheckFailure(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:    "validation failure: missing keys",
+			name:    "validation failure: missing repo keys",
 			source:  cogito.Source{},
 			writer:  io.Discard,
 			wantErr: "check: source: missing keys: owner, repo, access_token",
+		},
+		{
+			name: "validation failure: missing gchat keys",
+			source: cogito.Source{
+				Sinks: []string{"gchat"},
+			},
+			writer:  io.Discard,
+			wantErr: "check: source: missing keys: gchat_webhook",
 		},
 		{
 			name:    "write error",

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -31,24 +31,18 @@ func TestCheckSuccess(t *testing.T) {
 		assert.DeepEqual(t, have, tc.wantOut)
 	}
 
-	baseSource := cogito.Source{
-		Owner:       "the-owner",
-		Repo:        "the-repo",
-		AccessToken: "the-token",
-	}
-
 	testCases := []testCase{
 		{
 			name: "first request (Concourse omits the version field)",
 			request: cogito.CheckRequest{
-				Source: baseSource,
+				Source: baseGithubSource,
 			},
 			wantOut: []cogito.Version{{Ref: "dummy"}},
 		},
 		{
 			name: "subsequent requests (Concourse adds the version field)",
 			request: cogito.CheckRequest{
-				Source:  baseSource,
+				Source:  baseGithubSource,
 				Version: cogito.Version{Ref: "dummy"},
 			},
 			wantOut: []cogito.Version{{Ref: "dummy"}},
@@ -56,10 +50,7 @@ func TestCheckSuccess(t *testing.T) {
 		{
 			name: "first request (Concourse omits the version field) gchat only",
 			request: cogito.CheckRequest{
-				Source: cogito.Source{
-					Sinks:        []string{"gchat"},
-					GChatWebHook: "https://dummy-webhook",
-				},
+				Source: baseGchatSource,
 			},
 			wantOut: []cogito.Version{{Ref: "dummy"}},
 		},
@@ -90,12 +81,6 @@ func TestCheckFailure(t *testing.T) {
 		assert.Error(t, err, tc.wantErr)
 	}
 
-	baseSource := cogito.Source{
-		Owner:       "the-owner",
-		Repo:        "the-repo",
-		AccessToken: "the-token",
-	}
-
 	testCases := []testCase{
 		{
 			name:    "validation failure: missing repo keys",
@@ -113,7 +98,7 @@ func TestCheckFailure(t *testing.T) {
 		},
 		{
 			name:    "write error",
-			source:  baseSource,
+			source:  baseGithubSource,
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "check: preparing output: test write error",
 		},

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -97,6 +97,14 @@ func TestCheckFailure(t *testing.T) {
 			wantErr: "check: source: missing keys: gchat_webhook",
 		},
 		{
+			name: "validation failure: wrong sink key",
+			source: cogito.Source{
+				Sinks: []string{"slack", "gchat"},
+			},
+			writer:  io.Discard,
+			wantErr: "check: source: invalid sink: [slack]. Supported sinks: [gchat github]",
+		},
+		{
 			name:    "write error",
 			source:  baseGithubSource,
 			writer:  &testhelp.FailingWriter{},

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -116,6 +116,14 @@ func TestGetFailure(t *testing.T) {
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "get: source: missing keys: gchat_webhook",
 		},
+		{
+			name: "validation failure: wrong sink key",
+			source: cogito.Source{
+				Sinks: []string{"slack", "gchat"},
+			},
+			writer:  io.Discard,
+			wantErr: "get: source: invalid sink: [slack]. Supported sinks: [gchat github]",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -119,10 +119,10 @@ func TestGetFailure(t *testing.T) {
 		{
 			name: "validation failure: wrong sink key",
 			source: cogito.Source{
-				Sinks: []string{"slack", "gchat"},
+				Sinks: []string{"ghost", "gchat"},
 			},
 			writer:  io.Discard,
-			wantErr: "get: source: invalid sink: [slack]. Supported sinks: [gchat github]",
+			wantErr: "get: source: invalid sink(s): [ghost]. Supported sinks: [gchat github]",
 		},
 	}
 

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -31,22 +31,11 @@ func TestGetSuccess(t *testing.T) {
 		assert.DeepEqual(t, have, tc.wantOut)
 	}
 
-	baseGitSource := cogito.Source{
-		Owner:       "the-owner",
-		Repo:        "the-repo",
-		AccessToken: "the-token",
-	}
-
-	baseGchatSource := cogito.Source{
-		Sinks:        []string{"gchat"},
-		GChatWebHook: "https://the-webhook",
-	}
-
 	testCases := []testCase{
 		{
 			name: "returns requested version",
 			request: cogito.GetRequest{
-				Source:  baseGitSource,
+				Source:  baseGithubSource,
 				Version: cogito.Version{Ref: "banana"},
 			},
 			wantOut: cogito.Output{Version: cogito.Version{Ref: "banana"}},
@@ -92,12 +81,6 @@ func TestGetFailure(t *testing.T) {
 		assert.Error(t, err, tc.wantErr)
 	}
 
-	baseSource := cogito.Source{
-		Owner:       "the-owner",
-		Repo:        "the-repo",
-		AccessToken: "the-token",
-	}
-
 	testCases := []testCase{
 		{
 			name:    "user validation failure: missing keys",
@@ -107,13 +90,13 @@ func TestGetFailure(t *testing.T) {
 		},
 		{
 			name:    "concourse validation failure: empty version field",
-			source:  baseSource,
+			source:  baseGithubSource,
 			writer:  io.Discard,
 			wantErr: "get: empty 'version' field",
 		},
 		{
 			name:    "concourse validation failure: missing output directory",
-			source:  baseSource,
+			source:  baseGithubSource,
 			version: cogito.Version{Ref: "dummy"},
 			writer:  io.Discard,
 			wantErr: "get: arguments: missing output directory",
@@ -121,7 +104,7 @@ func TestGetFailure(t *testing.T) {
 		{
 			name:    "system write error",
 			args:    []string{"dummy-dir"},
-			source:  baseSource,
+			source:  baseGithubSource,
 			version: cogito.Version{Ref: "dummy"},
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "get: preparing output: test write error",

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -31,17 +31,30 @@ func TestGetSuccess(t *testing.T) {
 		assert.DeepEqual(t, have, tc.wantOut)
 	}
 
-	baseSource := cogito.Source{
+	baseGitSource := cogito.Source{
 		Owner:       "the-owner",
 		Repo:        "the-repo",
 		AccessToken: "the-token",
+	}
+
+	baseGchatSource := cogito.Source{
+		Sinks:        []string{"gchat"},
+		GChatWebHook: "https://the-webhook",
 	}
 
 	testCases := []testCase{
 		{
 			name: "returns requested version",
 			request: cogito.GetRequest{
-				Source:  baseSource,
+				Source:  baseGitSource,
+				Version: cogito.Version{Ref: "banana"},
+			},
+			wantOut: cogito.Output{Version: cogito.Version{Ref: "banana"}},
+		},
+		{
+			name: "returns requested version, gchat only",
+			request: cogito.GetRequest{
+				Source:  baseGchatSource,
 				Version: cogito.Version{Ref: "banana"},
 			},
 			wantOut: cogito.Output{Version: cogito.Version{Ref: "banana"}},
@@ -112,6 +125,13 @@ func TestGetFailure(t *testing.T) {
 			version: cogito.Version{Ref: "dummy"},
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "get: preparing output: test write error",
+		},
+		{
+			name:    "missing gchat webhook",
+			source:  cogito.Source{Sinks: []string{"gchat"}},
+			version: cogito.Version{Ref: "dummy"},
+			writer:  &testhelp.FailingWriter{},
+			wantErr: "get: source: missing keys: gchat_webhook",
 		},
 	}
 

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -231,6 +231,9 @@ func (src *Source) Validate() error {
 		if sinksSet.Contains("gchat") {
 			isGchatOptional = false
 		}
+		if !(sinksSet.Contains("gchat") || sinksSet.Contains("github")) {
+			return fmt.Errorf("source: invalid sink: %s. Supported sinks: 'gchat', 'github'", sinksSet)
+		}
 	}
 	var mandatory []string
 	if src.Owner == "" && isGitMandatory {

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -228,7 +228,7 @@ func (src *Source) Validate() error {
 		// First validate sinks are known and supported.
 		sinksNotValid := sinksSet.Difference(defaultSinksSet)
 		if sinksNotValid.Size() > 0 {
-			return fmt.Errorf("source: invalid sink: %s. Supported sinks: %s", sinksNotValid, defaultSinks)
+			return fmt.Errorf("source: invalid sink(s): %s. Supported sinks: %s", sinksNotValid, defaultSinks)
 		}
 	}
 

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -221,18 +221,22 @@ func (src *Source) Validate() error {
 
 	isGitMandatory := true
 	isGchatOptional := true
+
 	// If sinks are specified and 'github' is not found, Git sources are not mandatory.
 	// If sinks are specified and 'gchat' is found, gChat sources are not optional.
 	if len(src.Sinks) > 0 {
 		sinksSet := sets.From(src.Sinks...)
+		defaultSinks := []string{"gchat", "github"}
+		defaultSinksSet := sets.From(defaultSinks...)
 		if !sinksSet.Contains("github") {
 			isGitMandatory = false
 		}
 		if sinksSet.Contains("gchat") {
 			isGchatOptional = false
 		}
-		if !(sinksSet.Contains("gchat") || sinksSet.Contains("github")) {
-			return fmt.Errorf("source: invalid sink: %s. Supported sinks: 'gchat', 'github'", sinksSet)
+		sinksNotValid := sinksSet.Difference(defaultSinksSet)
+		if sinksNotValid.Size() > 0 {
+			return fmt.Errorf("source: invalid sink: %s. Supported sinks: %s", sinksNotValid, defaultSinks)
 		}
 	}
 	var mandatory []string

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -77,10 +77,28 @@ func TestSourceValidationFailure(t *testing.T) {
 		{
 			name: "invalid sink source keys",
 			source: cogito.Source{
-				Sinks:        []string{"gchat", "slacks"},
+				Sinks:        []string{"gchat", "ghost"},
 				GChatWebHook: "sensitive-gchat-webhook",
 			},
-			wantErr: "source: invalid sink: [slacks]. Supported sinks: [gchat github]",
+			wantErr: "source: invalid sink(s): [ghost]. Supported sinks: [gchat github]",
+		},
+		{
+			name: "multiple invalid sink source keys",
+			source: cogito.Source{
+				Sinks: []string{"coffee", "shop"},
+			},
+			wantErr: "source: invalid sink(s): [coffee shop]. Supported sinks: [gchat github]",
+		},
+		{
+			name: "multiple mixed invalid/valid sink source keys",
+			source: cogito.Source{
+				Sinks:        []string{"coffee", "shop", "closed", "gchat", "github"},
+				GChatWebHook: "sensitive-gchat-webhook",
+				Owner:        "the-owner",
+				Repo:         "the-repo",
+				AccessToken:  "the-token",
+			},
+			wantErr: "source: invalid sink(s): [closed coffee shop]. Supported sinks: [gchat github]",
 		},
 	}
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -164,7 +164,8 @@ gchat_webhook:         ***REDACTED***
 log_level:             debug
 context_prefix:        the-prefix
 chat_append_summary:   true
-chat_notify_on_states: [success failure]`
+chat_notify_on_states: [success failure]
+sinks: []`
 
 		have := fmt.Sprint(source)
 
@@ -182,7 +183,8 @@ gchat_webhook:
 log_level:             
 context_prefix:        
 chat_append_summary:   false
-chat_notify_on_states: []`
+chat_notify_on_states: []
+sinks: []`
 
 		have := fmt.Sprint(input)
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -71,9 +71,14 @@ func TestSourceValidationFailure(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:    "missing mandatory source keys",
+			name:    "missing mandatory git source keys",
 			source:  cogito.Source{},
 			wantErr: "source: missing keys: owner, repo, access_token",
+		},
+		{
+			name:    "missing mandatory gchat source keys",
+			source:  cogito.Source{Sinks: []string{"gchat"}},
+			wantErr: "source: missing keys: gchat_webhook",
 		},
 	}
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -80,6 +80,14 @@ func TestSourceValidationFailure(t *testing.T) {
 			source:  cogito.Source{Sinks: []string{"gchat"}},
 			wantErr: "source: missing keys: gchat_webhook",
 		},
+		{
+			name: "invalid sink source keys",
+			source: cogito.Source{
+				Sinks:        []string{"gchat", "slacks"},
+				GChatWebHook: "sensitive-gchat-webhook",
+			},
+			wantErr: "source: invalid sink: [slacks]. Supported sinks: [gchat github]",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -26,21 +26,15 @@ func TestSourceValidationSuccess(t *testing.T) {
 		assert.NilError(t, err)
 	}
 
-	baseSource := cogito.Source{
-		Owner:       "the-owner",
-		Repo:        "the-repo",
-		AccessToken: "the-token",
-	}
-
 	testCases := []testCase{
 		{
 			name:     "only mandatory keys",
-			mkSource: func() cogito.Source { return baseSource },
+			mkSource: func() cogito.Source { return baseGithubSource },
 		},
 		{
 			name: "explicit log_level",
 			mkSource: func() cogito.Source {
-				source := baseSource
+				source := baseGithubSource
 				source.LogLevel = "debug"
 				return source
 			},

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -186,6 +186,34 @@ func TestPutterLoadConfigurationInvalidParamsFailure(t *testing.T) {
 	assert.Error(t, err, wantErr)
 }
 
+func TestPutterLoadConfigurationMissingGchatwebHook(t *testing.T) {
+	in := []byte(`
+{
+  "source": {"sinks": ["gchat"]},
+  "params": {}
+}`)
+	wantErr := `put: source: missing keys: gchat_webhook`
+	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+
+	err := putter.LoadConfiguration(in, nil)
+
+	assert.Error(t, err, wantErr)
+}
+
+func TestPutterLoadConfigurationUnknownSink(t *testing.T) {
+	in := []byte(`
+{
+  "source": {"sinks": ["pizza"]},
+  "params": {}
+}`)
+	wantErr := `put: source: invalid sink: [pizza]. Supported sinks: 'gchat', 'github'`
+	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+
+	err := putter.LoadConfiguration(in, nil)
+
+	assert.Error(t, err, wantErr)
+}
+
 func TestPutterProcessInputDirSuccess(t *testing.T) {
 	type testCase struct {
 		name     string

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -249,11 +249,12 @@ func TestPutterProcessInputDirFailure(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		/*{
+		{
 			name:     "no input dirs",
 			inputDir: "testdata/empty-dir",
+			params:   cogito.PutParams{Sinks: []string{"github"}},
 			wantErr:  "put:inputs: missing directory for GitHub repo: have: [], GitHub: dummy-owner/dummy-repo",
-		},*/
+		},
 		{
 			name:     "two input dirs",
 			inputDir: "testdata/two-dirs",

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -206,7 +206,7 @@ func TestPutterLoadConfigurationUnknownSink(t *testing.T) {
   "source": {"sinks": ["pizza"]},
   "params": {}
 }`)
-	wantErr := `put: source: invalid sink: [pizza]. Supported sinks: 'gchat', 'github'`
+	wantErr := `put: source: invalid sink: [pizza]. Supported sinks: [gchat github]`
 	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -217,10 +217,12 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		tmpDir := testhelp.MakeGitRepoFromTestdata(t, tc.inputDir,
-			"https://github.com/dummy-owner/dummy-repo", "dummySHA", "banana")
 		putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
-		putter.InputDir = filepath.Join(tmpDir, filepath.Base(tc.inputDir))
+		if tc.inputDir != "" {
+			tmpDir := testhelp.MakeGitRepoFromTestdata(t, tc.inputDir,
+				"https://github.com/dummy-owner/dummy-repo", "dummySHA", "banana")
+			putter.InputDir = filepath.Join(tmpDir, filepath.Base(tc.inputDir))
+		}
 		putter.Request = cogito.PutRequest{
 			Source: cogito.Source{Owner: "dummy-owner", Repo: "dummy-repo", Sinks: []string{tc.sink}},
 			Params: tc.params,
@@ -242,9 +244,24 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 			params:   cogito.PutParams{ChatMessageFile: "msgdir/msg.txt"},
 		},
 		{
-			name:     "no input dirs, but sink 'gchat' is set",
-			inputDir: "testdata/empty-dir",
+			name: "no input dirs, but sink 'gchat' is set",
+			sink: "gchat",
+		},
+		{
+			name:     "only msg dir, but gchat is set",
+			inputDir: "testdata/repo-and-msgdir/msgdir",
 			sink:     "gchat",
+		},
+		{
+			name:     "only msg dir and message file, but gchat is set",
+			inputDir: "testdata/repo-and-msgdir/msgdir",
+			sink:     "gchat",
+			params:   cogito.PutParams{ChatMessageFile: "msgdir/msg.txt"},
+		},
+		{
+			name:   "sinks are correctly overrides by put params",
+			sink:   "github",
+			params: cogito.PutParams{Sinks: []string{"gchat"}},
 		},
 	}
 

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -208,6 +208,20 @@ func TestPutterLoadConfigurationUnknownSink(t *testing.T) {
 	assert.Error(t, err, wantErr)
 }
 
+func TestPutterLoadConfigurationUnknownSinkPutParams(t *testing.T) {
+	in := []byte(`
+{
+  "source": {"sinks": ["gchat"], "gchat_webhook": "dummy-webhook"},
+  "params": {"sinks": ["pizza"]}
+}`)
+	wantErr := `put: arguments: unsupported sink: pizza`
+	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+
+	err := putter.LoadConfiguration(in, nil)
+
+	assert.Error(t, err, wantErr)
+}
+
 func TestPutterProcessInputDirSuccess(t *testing.T) {
 	type testCase struct {
 		name     string

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -191,6 +191,7 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 		name     string
 		inputDir string
 		params   cogito.PutParams
+		sink     string
 	}
 
 	test := func(t *testing.T, tc testCase) {
@@ -199,7 +200,7 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 		putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 		putter.InputDir = filepath.Join(tmpDir, filepath.Base(tc.inputDir))
 		putter.Request = cogito.PutRequest{
-			Source: cogito.Source{Owner: "dummy-owner", Repo: "dummy-repo"},
+			Source: cogito.Source{Owner: "dummy-owner", Repo: "dummy-repo", Sinks: []string{tc.sink}},
 			Params: tc.params,
 		}
 
@@ -217,6 +218,11 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 			name:     "two dirs: repo and msg file",
 			inputDir: "testdata/repo-and-msgdir",
 			params:   cogito.PutParams{ChatMessageFile: "msgdir/msg.txt"},
+		},
+		{
+			name:     "no input dirs, but sink 'gchat' is set",
+			inputDir: "testdata/empty-dir",
+			sink:     "gchat",
 		},
 	}
 
@@ -251,6 +257,11 @@ func TestPutterProcessInputDirFailure(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     "no input dirs",
+			inputDir: "testdata/empty-dir",
+			wantErr:  "put:inputs: missing directory for GitHub repo: have: [], GitHub: dummy-owner/dummy-repo",
+		},
+		{
+			name:     "no input dirs and sink 'github' is set",
 			inputDir: "testdata/empty-dir",
 			params:   cogito.PutParams{Sinks: []string{"github"}},
 			wantErr:  "put:inputs: missing directory for GitHub repo: have: [], GitHub: dummy-owner/dummy-repo",

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -200,7 +200,7 @@ func TestPutterLoadConfigurationUnknownSink(t *testing.T) {
   "source": {"sinks": ["pizza"]},
   "params": {}
 }`)
-	wantErr := `put: source: invalid sink: [pizza]. Supported sinks: [gchat github]`
+	wantErr := `put: source: invalid sink(s): [pizza]. Supported sinks: [gchat github]`
 	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)
@@ -273,7 +273,7 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 			params:   cogito.PutParams{ChatMessageFile: "msgdir/msg.txt"},
 		},
 		{
-			name:   "sinks are correctly overrides by put params",
+			name:   "sinks are correctly overridden by put params",
 			sink:   "github",
 			params: cogito.PutParams{Sinks: []string{"gchat"}},
 		},

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -13,17 +13,11 @@ import (
 )
 
 var (
-	baseSource = cogito.Source{
-		Owner:       "the-owner",
-		Repo:        "the-repo",
-		AccessToken: "the-token",
-	}
-
 	// StateError is sent to notification sinks by default.
 	baseParams = cogito.PutParams{State: cogito.StateError}
 
 	basePutRequest = cogito.PutRequest{
-		Source: baseSource,
+		Source: baseGithubSource,
 		Params: baseParams,
 	}
 )
@@ -154,7 +148,7 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 		{
 			name: "params: invalid",
 			putInput: cogito.PutRequest{
-				Source: baseSource,
+				Source: baseGithubSource,
 				Params: cogito.PutParams{State: "burnt-pizza"},
 			},
 			wantErr: "put: parsing request: invalid build state: burnt-pizza",
@@ -337,7 +331,7 @@ func TestPutterProcessInputDirFailure(t *testing.T) {
 func TestPutterProcessInputDirNonExisting(t *testing.T) {
 	putter := &cogito.ProdPutter{
 		InputDir: "non-existing",
-		Request:  cogito.PutRequest{Source: baseSource},
+		Request:  cogito.PutRequest{Source: baseGithubSource},
 	}
 
 	err := putter.ProcessInputDir()

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -85,18 +85,22 @@ func (putter *ProdPutter) ProcessInputDir() error {
 
 	params := putter.Request.Params
 	source := putter.Request.Source
+	sinks := sets.From(source.Sinks...)
 	var msgDir string
 
+	if len(putter.InputDir) == 0 && (sinks.Size() > 0 && !sinks.Contains("github")) {
+		// Nothing to validate, InputDir is not mandatory if only chat feature is requested.
+		// Later, will repeat the check for collected directories.
+		return nil
+	}
 	collected, err := collectInputDirs(putter.InputDir)
 	if err != nil {
 		return err
 	}
 
-	sinks := sets.From(source.Sinks...)
-
 	inputDirs := sets.From(collected...)
 	// If putter.InputDir is not set, it is likely only Cogito chat feature is requested.
-	// Sinks can be set as Source, let check if is configured and 'github' keyword
+	// Sinks can be set as Source, let check if they are configured and 'github' keyword
 	// is present. Also we return an error if 'sinks' is not configured in this case.
 	if inputDirs.Size() == 0 && (sinks.Size() == 0 || sinks.Contains("github")) {
 		return fmt.Errorf(

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -91,6 +91,11 @@ func (putter *ProdPutter) ProcessInputDir() error {
 	}
 
 	inputDirs := sets.From(collected...)
+	// If putter.InputDir is not set, it is likely only Cogito chat feature is requested.
+	// If there is an error in the configuration, the Validate() function will report.
+	if inputDirs.Size() == 0 {
+		return nil
+	}
 
 	if params.ChatMessageFile != "" {
 		msgDir, _ = path.Split(params.ChatMessageFile)

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -51,13 +51,15 @@ func (putter *ProdPutter) LoadConfiguration(input []byte, args []string) error {
 		"environment", putter.Request.Env,
 		"args", args)
 
+	sinks := putter.Request.Source.Sinks
 	// args[0] contains the path to a directory containing all the "put inputs".
-	if len(args) == 0 {
+	if len(args) == 0 && len(sinks) == 0 {
 		return fmt.Errorf("put: arguments: missing input directory")
 	}
-	putter.InputDir = args[0]
-	putter.log.Debug("", "input-directory", putter.InputDir)
-
+	if len(args) > 0 {
+		putter.InputDir = args[0]
+		putter.log.Debug("", "input-directory", putter.InputDir)
+	}
 	buildState := putter.Request.Params.State
 	putter.log.Debug("", "state", buildState)
 

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -63,7 +63,7 @@ func (putter *ProdPutter) LoadConfiguration(input []byte, args []string) error {
 	}
 	sinksSet := sets.From(sinks...)
 	// If only gchat is required, the next check will be skipped.
-	required := !(sinksSet.Contains("gchat") && len(sinks) == 1)
+	required := !sinksSet.Contains("gchat") || len(sinks) != 1
 
 	// args[0] contains the path to a directory containing all the "put inputs".
 	if len(args) == 0 && required {

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -118,16 +118,18 @@ func (putter *ProdPutter) ProcessInputDir() error {
 
 	inputDirs := sets.From(collected...)
 	// If putter.InputDir is not set, it is likely only Cogito chat feature is requested.
-	// Sinks can be set as Source, let check if they are configured and 'github' keyword
-	// is present. Also we return an error if 'sinks' is not configured in this case.
-	if inputDirs.Size() == 0 && (sinks.Size() == 0 || sinks.Contains("github")) {
-		return fmt.Errorf(
-			"put:inputs: missing directory for GitHub repo: have: %v, GitHub: %s/%s",
-			inputDirs, source.Owner, source.Repo)
-	}
-	// No errors, inputDirs is not mandatory at this point.
-	if inputDirs.Size() == 0 && (sinks.Size() > 0 && !sinks.Contains("github")) {
-		return nil
+	if inputDirs.Size() == 0 {
+		// If there are no sinks specified or if they are specified and 'github' is found,
+		// the inputs parameter is missing.
+		if sinks.Size() == 0 || sinks.Contains("github") {
+			return fmt.Errorf(
+				"put:inputs: missing directory for GitHub repo: have: %v, GitHub: %s/%s",
+				inputDirs, source.Owner, source.Repo)
+		}
+		// If sinks are specified and 'github' is not found, that's ok.
+		if sinks.Size() > 0 && !sinks.Contains("github") {
+			return nil
+		}
 	}
 
 	if params.ChatMessageFile != "" {

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -85,7 +85,12 @@ func (putter *ProdPutter) ProcessInputDir() error {
 
 	params := putter.Request.Params
 	source := putter.Request.Source
+
 	sinks := sets.From(source.Sinks...)
+	if len(params.Sinks) > 0 {
+		sinks = sets.From(params.Sinks...)
+	}
+
 	var msgDir string
 
 	if len(putter.InputDir) == 0 && (sinks.Size() > 0 && !sinks.Contains("github")) {

--- a/cogito/vars_test.go
+++ b/cogito/vars_test.go
@@ -1,0 +1,15 @@
+package cogito_test
+
+import "github.com/Pix4D/cogito/cogito"
+
+var (
+	baseGithubSource = cogito.Source{
+		Owner:       "the-owner",
+		Repo:        "the-repo",
+		AccessToken: "the-token",
+	}
+	baseGchatSource = cogito.Source{
+		Sinks:        []string{"gchat"},
+		GChatWebHook: "https://dummy-webhook",
+	}
+)


### PR DESCRIPTION
Part of: [PCI-2665](https://pix4dbug.atlassian.net/browse/PCI-2665)

The resource Source configuration now parses the `sinks` parameter.

Example:

Obviously the example below is not realistic, we don't need to specify the default.
```yaml
resources:
- name: gh-status
  type: cogito
  check_every: never
  source:
    owner: ((github-owner))
    repo: ((your-repo-name))
    access_token: ((github-PAT))
    sinks: ["github", "gchat"]
```

A more realistic example:
```yaml
resources:
- name: gchat
  type: cogito
  check_every: never
  source:
    sinks: ["gchat"],
    gchat_webhook: https://my-chat-webhook
```
Note that when specifying the sink and only chat feature, the GitHub parameter are not mandatory anymore, but the webhook will be.

Best to review commit by commit.

### Todos

- [ ] Update documentation (separate PR)
- [ ] make a new relase

I didn't touch the documentation yet, I prefer to wait for your feedback.