### PR TITLE
Cogito independent chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.0] - UNRELEASED
+
+This release allows to use cogito purely to send chat notifications, completely independently from GitHub. This allows to use cogito in place of concourse-hangouts-resource in any situation.
+
+### Added
+
+- Notion of sink, representing an API destination (`github` and `gchat`). The optional keys `source.sinks` and `put.params.sinks` allow further control on the destination of a put.
+
+### Changed
+
+- Configuring a GitHub repository is not mandatory any more, to allow cogito to be used purely for chat notification.
+- Documentation addresses explicitly how to configure cogito based on the three possible use cases: GitHub only, GitHub + Chat, Chat only.
+
 ## [v0.8.2] - 2022-11-18
 
 ### Minor breaking change
@@ -14,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.8.1] - 2022-09-07
 
-This release allows to use cogito for all chat notifications where previously one would have needed a mix of cogito and concourse-hangouts-resource.
+This release allows to use cogito for the vast majority of chat notifications where previously one would have needed a mix of cogito and concourse-hangouts-resource.
 
 ### Added
 
@@ -211,4 +224,6 @@ This release allows to use cogito for all chat notifications where previously on
 [v0.7.1]: https://github.com/Pix4D/cogito/releases/tag/v0.7.1
 [v0.8.0]: https://github.com/Pix4D/cogito/releases/tag/v0.8.0
 [v0.8.1]: https://github.com/Pix4D/cogito/releases/tag/v0.8.1
+[v0.8.2]: https://github.com/Pix4D/cogito/releases/tag/v0.8.2
+[v0.9.0]: https://github.com/Pix4D/cogito/releases/tag/v0.9.0
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -156,6 +156,9 @@ tasks:
       - task: test:acceptance:chat-message-default
       - task: test:acceptance:chat-message-no-summary
       - task: test:acceptance:chat-message-file-default
+      - task: test:acceptance:chat-message-only-sinks-override
+      - task: test:acceptance:chat-message-only-simplest-possible
+      - task: test:acceptance:chat-message-only-file
       - task: test:acceptance:default-log
 
   test:acceptance:chat-only-summary:
@@ -181,6 +184,24 @@ tasks:
     cmds:
       - task: trigger-job
         vars: {JOB: chat-message-file-default}
+
+  test:acceptance:chat-message-only-simplest-possible:
+    desc: Run a pipeline job to test chat only message
+    cmds:
+      - task: trigger-job
+        vars: {JOB: chat-message-only-simplest-possible}
+
+  test:acceptance:chat-message-only-sinks-override:
+    desc: Run a pipeline job to test chat only message
+    cmds:
+      - task: trigger-job
+        vars: {JOB: chat-message-only-sinks-override}
+
+  test:acceptance:chat-message-only-file:
+    desc: Run a pipeline job to test chat only chat_message_file
+    cmds:
+      - task: trigger-job
+        vars: {JOB: chat-message-only-file}
 
   test:acceptance:default-log:
     desc: Run a pipeline job to test default logging

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -111,10 +111,6 @@ func gChatBuildSummaryText(gitRef string, state BuildState, src Source, env Envi
 	// https://github.com/Pix4D/cogito/commit/e8c6e2ac0318b5f0baa3f55
 	job := fmt.Sprintf("<%s|%s/%s>",
 		concourseBuildURL(env), env.BuildJobName, env.BuildName)
-	commitUrl := fmt.Sprintf("https://github.com/%s/%s/commit/%s",
-		src.Owner, src.Repo, gitRef)
-	commit := fmt.Sprintf("<%s|%.10s> (repo: %s/%s)",
-		commitUrl, gitRef, src.Owner, src.Repo)
 
 	// Unfortunately the font is proportional and doesn't support tabs,
 	// so we cannot align in columns.
@@ -123,7 +119,14 @@ func gChatBuildSummaryText(gitRef string, state BuildState, src Source, env Envi
 	fmt.Fprintf(&bld, "*pipeline* %s\n", env.BuildPipelineName)
 	fmt.Fprintf(&bld, "*job* %s\n", job)
 	fmt.Fprintf(&bld, "*state* %s\n", decorateState(state))
-	fmt.Fprintf(&bld, "*commit* %s\n", commit)
+	// An empty gitRef means that cogito has been configured as chat only.
+	if gitRef != "" {
+		commitUrl := fmt.Sprintf("https://github.com/%s/%s/commit/%s",
+			src.Owner, src.Repo, gitRef)
+		commit := fmt.Sprintf("<%s|%.10s> (repo: %s/%s)",
+			commitUrl, gitRef, src.Owner, src.Repo)
+		fmt.Fprintf(&bld, "*commit* %s\n", commit)
+	}
 
 	return bld.String()
 }

--- a/cogito/gchatsink_private_test.go
+++ b/cogito/gchatsink_private_test.go
@@ -63,6 +63,13 @@ func TestShouldSendToChatCustomConfig(t *testing.T) {
 	}
 }
 
+func TestPrepareChatMessageOnlyChatSuccess(t *testing.T) {
+	have, err := prepareChatMessage(nil, PutRequest{}, "")
+
+	assert.NilError(t, err)
+	assert.Check(t, !strings.Contains(have, "commit"), "not wanted: commit")
+}
+
 func TestPrepareChatMessageSuccess(t *testing.T) {
 	type testCase struct {
 		name        string

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -31,7 +31,7 @@ func TestGetSuccess(t *testing.T) {
 		assert.DeepEqual(t, have, tc.wantOut)
 	}
 
-	baseSource := cogito.Source{
+	baseGithubSource := cogito.Source{
 		Owner:       "the-owner",
 		Repo:        "the-repo",
 		AccessToken: "the-token",
@@ -41,7 +41,7 @@ func TestGetSuccess(t *testing.T) {
 		{
 			name: "returns requested version",
 			request: cogito.GetRequest{
-				Source:  baseSource,
+				Source:  baseGithubSource,
 				Version: cogito.Version{Ref: "banana"},
 			},
 			wantOut: cogito.Output{Version: cogito.Version{Ref: "banana"}},
@@ -79,7 +79,7 @@ func TestGetFailure(t *testing.T) {
 		assert.Error(t, err, tc.wantErr)
 	}
 
-	baseSource := cogito.Source{
+	baseGithubSource := cogito.Source{
 		Owner:       "the-owner",
 		Repo:        "the-repo",
 		AccessToken: "the-token",
@@ -94,13 +94,13 @@ func TestGetFailure(t *testing.T) {
 		},
 		{
 			name:    "concourse validation failure: empty version field",
-			source:  baseSource,
+			source:  baseGithubSource,
 			writer:  io.Discard,
 			wantErr: "get: empty 'version' field",
 		},
 		{
 			name:    "concourse validation failure: missing output directory",
-			source:  baseSource,
+			source:  baseGithubSource,
 			version: cogito.Version{Ref: "dummy"},
 			writer:  io.Discard,
 			wantErr: "get: arguments: missing output directory",
@@ -108,10 +108,23 @@ func TestGetFailure(t *testing.T) {
 		{
 			name:    "system write error",
 			args:    []string{"dummy-dir"},
-			source:  baseSource,
+			source:  baseGithubSource,
 			version: cogito.Version{Ref: "dummy"},
 			writer:  &testhelp.FailingWriter{},
 			wantErr: "get: preparing output: test write error",
+		},
+		{
+			name:    "user missing gchat webhook",
+			source:  cogito.Source{Sinks: []string{"gchat"}},
+			version: cogito.Version{Ref: "dummy"},
+			writer:  &testhelp.FailingWriter{},
+			wantErr: "get: source: missing keys: gchat_webhook",
+		},
+		{
+			name:    "user validation failure: wrong sink key",
+			source:  cogito.Source{Sinks: []string{"ghost", "gchat"}},
+			writer:  io.Discard,
+			wantErr: "get: source: invalid sink(s): [ghost]",
 		},
 	}
 

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -49,9 +49,11 @@ func Put(log hclog.Logger, input []byte, out io.Writer, args []string, putter Pu
 		return fmt.Errorf("put: %s", err)
 	}
 
-	// We invoke all the sinks and keep going also if some of them return an error.
 	var sinkErrors []error
-	for _, sink := range putter.Sinks() {
+	sinks := putter.Sinks()
+
+	// We invoke all the sinks and keep going also if some of them return an error.
+	for _, sink := range sinks {
 		if err := sink.Send(); err != nil {
 			sinkErrors = append(sinkErrors, err)
 		}

--- a/cogito/testdata/only-msgdir/msgdir/msg.txt
+++ b/cogito/testdata/only-msgdir/msgdir/msg.txt
@@ -1,0 +1,1 @@
+ten bananas please

--- a/pipelines/cogito-acceptance.yml
+++ b/pipelines/cogito-acceptance.yml
@@ -47,6 +47,16 @@ resources:
       gchat_webhook: ((gchat_webhook))
       chat_notify_on_states: [abort, error, failure, pending, success]
 
+  - name: cogito-chat-only
+    type: cogito
+    check_every: never
+    source:
+      log_level: debug
+      sinks:
+      - gchat
+      gchat_webhook: ((gchat_webhook))
+      chat_notify_on_states: [abort, error, failure, pending, success]
+
   - name: target-repo.git
     type: git
     source:
@@ -102,6 +112,32 @@ jobs:
           state: success
           chat_message_file: "messagedir/message.txt"
 
+  - name: chat-message-only-simplest-possible
+    plan:
+      - put: cogito-chat-only
+        inputs: []
+        params:
+          chat_message: "This is the custom chat message."
+
+  - name: chat-message-only-sinks-override
+    plan:
+      - put: cogito
+        inputs: []
+        params:
+          sinks:
+            - gchat
+          chat_message: "This is the custom chat message."
+
+  - name: chat-message-only-file
+    plan:
+      - get: cogito-repo.git
+      - task: generate-message-file
+        file: cogito-repo.git/pipelines/tasks/generate-message-file.yml
+      - put: cogito-chat-only
+        inputs: [messagedir]
+        params:
+          chat_message_file: "messagedir/message.txt"
+
   - name: default-log
     plan:
       - get: target-repo.git
@@ -109,4 +145,3 @@ jobs:
         inputs: [target-repo.git]
         params:
           state: success
-


### PR DESCRIPTION
Part of: [PCI-2665](https://pix4dbug.atlassian.net/browse/PCI-2665)

### Details
A new optional field is added and its name is `sinks`. It takes a slice of strings as values, corresponding to all Cogito supported sinks. 
This parameter can be set as `source.sinks` and/or `put.params.sinks` level. The latter if specified overrides the source configuration.  
In order to be backward compatible, if nothing is specified it behaviors as before defaulting to all supported sinks. 



Best review commit by commit.

### Tests criteria

![image](https://user-images.githubusercontent.com/9631930/203501616-59cafef8-9eed-4fa3-a21c-72a0e85ce1e4.png)

The acceptance test, aka e2e tests, are increased by new CI jobs around the only chat feature:
* send message to chat using a standard Cogito resource, but specify the sink `gchat` in `put.params`.
* send message to chat using a custom only chat Cogito resource.
* send message to chat using a custom only chat Cogito resource plus setting a message directory and a message file.

![image](https://user-images.githubusercontent.com/9631930/203502811-ca31b758-13ca-486e-9fdf-210016036e62.png)

The test coverage has slightly decreased (from 99.5% to 99.0%), I couldn't cover a special case using unit tests. Happily, it's covered by the acceptance tests.
Actually, the code below:

![image](https://user-images.githubusercontent.com/9631930/203503511-5c2a3ac4-0b59-4682-9ad7-7307e8c9b522.png)

is executed clearly in the following CI job (see the red arrow):

![image](https://user-images.githubusercontent.com/9631930/203503916-44cb42a1-173c-4782-80e5-8856e3e0ca8c.png)



### Todos
- [ ] Update remaining pipelines: replace Hangouts resource
