### PR TITLE
PCI-3118 update ci tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on: [push]
 name: ci
 
 env:
-  go-version: 1.18.x
-  task-version: v3.12.1
+  go-version: 1.20.x
+  task-version: v3.24.0
 
 jobs:
   all:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.20-alpine as builder
 
 ARG BUILD_INFO
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,8 +27,8 @@ vars:
       "version": {"ref": "pizza"}
     }
   #
-  GOLANGCI_VERSION: v1.48.0
-  TPARSE_VERSION: v0.11.1
+  GOLANGCI_VERSION: v1.52.2
+  TPARSE_VERSION: v0.12.1
 
 tasks:
 


### PR DESCRIPTION
For me it was required upgrade becuase golangci did not work with go version I have installed. While I was at it I upgraded all other tools.

Updates:
- go to v1.20.X
- golangci to 1.52.2 (required with go >= v1.20.X)
- Task to v3.24.0
- tparse to v0.12.1