### PR TITLE
PCI-3118 github package refactoring

### DIFF
--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -23,7 +23,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 	context := ghMakeContext(sink.Request)
 
 	commitStatus := github.NewCommitStatus(sink.GhAPI, sink.Request.Source.AccessToken,
-		sink.Request.Source.Owner, sink.Request.Source.Repo, context)
+		sink.Request.Source.Owner, sink.Request.Source.Repo, context, sink.Log)
 	description := "Build " + sink.Request.Env.BuildName
 
 	sink.Log.Debug("posting to GitHub Commit Status API",

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -13,6 +13,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 // StatusError is one of the possible errors returned by the github package.
@@ -35,6 +37,8 @@ type CommitStatus struct {
 	owner   string
 	repo    string
 	context string
+
+	log hclog.Logger
 }
 
 // NewCommitStatus returns a CommitStatus object associated to a specific GitHub owner and repo.
@@ -46,8 +50,8 @@ type CommitStatus struct {
 //
 // See also:
 // https://docs.github.com/en/rest/commits/statuses#about-the-commit-statuses-api
-func NewCommitStatus(server, token, owner, repo, context string) CommitStatus {
-	return CommitStatus{server, token, owner, repo, context}
+func NewCommitStatus(server, token, owner, repo, context string, log hclog.Logger) CommitStatus {
+	return CommitStatus{server, token, owner, repo, context, log}
 }
 
 // AddRequest is the JSON object sent to the API.
@@ -83,6 +87,7 @@ func (s CommitStatus) Add(sha, state, targetURL, description string) error {
 		return fmt.Errorf("JSON encode: %w", err)
 	}
 
+	s.log.Info("making a Github REST API http request")
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBodyJSON))
 	if err != nil {
 		return fmt.Errorf("create http request: %w", err)

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -126,11 +126,8 @@ func (s CommitStatus) Add(sha, state, targetURL, description string) error {
 	//
 	// Since we cannot use this information to detect configuration errors, for the time being
 	// we report it in the error message.
-
-	XAcceptedOauthScope := resp.Header["X-Accepted-Oauth-Scopes"]
-	XOauthScopes := resp.Header["X-Oauth-Scopes"]
 	OAuthInfo := fmt.Sprintf("X-Accepted-Oauth-Scopes: %v, X-Oauth-Scopes: %v",
-		XAcceptedOauthScope, XOauthScopes)
+		resp.Header.Get("X-Accepted-Oauth-Scopes"), resp.Header.Get("X-Oauth-Scopes"))
 
 	respBody, _ := io.ReadAll(resp.Body)
 	var hint string

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/testhelp"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestGitHubStatusSuccessMockAPI(t *testing.T) {
@@ -41,7 +42,7 @@ func TestGitHubStatusSuccessMockAPI(t *testing.T) {
 		defer ts.Close()
 
 		t.Run(tc.name, func(t *testing.T) {
-			ghStatus := github.NewCommitStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context)
+			ghStatus := github.NewCommitStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context, hclog.NewNullLogger())
 			err := ghStatus.Add(cfg.SHA, state, targetURL, desc)
 			if err != nil {
 				t.Fatalf("\nhave: %s\nwant: <no error>", err)
@@ -108,7 +109,7 @@ OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
 
 		t.Run(tc.name, func(t *testing.T) {
 			wantErr := fmt.Sprintf(tc.wantErr, ts.URL)
-			ghStatus := github.NewCommitStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context)
+			ghStatus := github.NewCommitStatus(ts.URL, cfg.Token, cfg.Owner, cfg.Repo, context, hclog.NewNullLogger())
 			err := ghStatus.Add(cfg.SHA, state, targetURL, desc)
 
 			if err == nil {
@@ -140,7 +141,7 @@ func TestGitHubStatusSuccessIntegration(t *testing.T) {
 	desc := time.Now().Format("15:04:05")
 	state := "success"
 
-	ghStatus := github.NewCommitStatus(github.API, cfg.Token, cfg.Owner, cfg.Repo, context)
+	ghStatus := github.NewCommitStatus(github.API, cfg.Token, cfg.Owner, cfg.Repo, context, hclog.NewNullLogger())
 	err := ghStatus.Add(cfg.SHA, state, targetURL, desc)
 
 	if err != nil {
@@ -217,7 +218,7 @@ OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: [repo:status]`,
 			}
 
 			ghStatus := github.NewCommitStatus(github.API, tc.token, tc.owner, tc.repo,
-				"dummy-context")
+				"dummy-context", hclog.NewNullLogger())
 			err := ghStatus.Add(tc.sha, state, "dummy-url", "dummy-desc")
 
 			if err == nil {

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -74,7 +74,7 @@ Hint: one of the following happened:
     2. The user who issued the token doesn't have write access to the repo
     3. The token doesn't have scope repo:status
 Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
-OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
+OAuth: X-Accepted-Oauth-Scopes: , X-Oauth-Scopes: `,
 			wantStatus: http.StatusNotFound,
 		},
 		{
@@ -84,7 +84,7 @@ OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
 Body: fake body
 Hint: Github API is down
 Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
-OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
+OAuth: X-Accepted-Oauth-Scopes: , X-Oauth-Scopes: `,
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
@@ -94,7 +94,7 @@ OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
 Body: fake body
 Hint: none
 Action: POST %s/repos/fakeOwner/fakeRepo/statuses/0123456789012345678901234567890123456789
-OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
+OAuth: X-Accepted-Oauth-Scopes: , X-Oauth-Scopes: `,
 			wantStatus: http.StatusTeapot,
 		},
 	}
@@ -173,7 +173,7 @@ func TestGitHubStatusFailureIntegration(t *testing.T) {
 Body: {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
 Hint: Either wrong credentials or PAT expired (check your email for expiration notice)
 Action: POST https://api.github.com/repos/pix4d/cogito-test-read-write/statuses/751affd155db7a00d936ee6e9f483deee69c5922
-OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: []`,
+OAuth: X-Accepted-Oauth-Scopes: , X-Oauth-Scopes: `,
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
@@ -186,7 +186,7 @@ Hint: one of the following happened:
     2. The user who issued the token doesn't have write access to the repo
     3. The token doesn't have scope repo:status
 Action: POST https://api.github.com/repos/pix4d/non-existing-really/statuses/751affd155db7a00d936ee6e9f483deee69c5922
-OAuth: X-Accepted-Oauth-Scopes: [repo], X-Oauth-Scopes: [repo:status]`,
+OAuth: X-Accepted-Oauth-Scopes: repo, X-Oauth-Scopes: repo:status`,
 			wantStatus: http.StatusNotFound,
 		},
 		{
@@ -196,7 +196,7 @@ OAuth: X-Accepted-Oauth-Scopes: [repo], X-Oauth-Scopes: [repo:status]`,
 Body: {"message":"No commit found for SHA: e576e3aa7aaaa048b396e2f34fa24c9cf4d1e822","documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commit-status"}
 Hint: none
 Action: POST https://api.github.com/repos/pix4d/cogito-test-read-write/statuses/e576e3aa7aaaa048b396e2f34fa24c9cf4d1e822
-OAuth: X-Accepted-Oauth-Scopes: [], X-Oauth-Scopes: [repo:status]`,
+OAuth: X-Accepted-Oauth-Scopes: , X-Oauth-Scopes: repo:status`,
 			wantStatus: http.StatusUnprocessableEntity,
 		},
 	}


### PR DESCRIPTION
**commit 1**: github: pass the sink logger to github package
- enables logging from inside github package

**commit 2**:github: use 'http.Response.Header.Get(key)' to fetch the header

Advantages:
- http.Response.Header.Get(key) is an existing built-in method
- it handles canonicalization (go http server converts header keys into case-sensitive keys)
- caller doesn't need to check if the key exists or how many elements it has

Using `http.Response.Header.Get(key)` will be much more important when inspecting `rate limit` related headers.
