### PR TITLE
github: calculate sleep time based on Github server time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.10.1] - 2023-05-17
+
+### Added
+
+- Adds a jitter time to calculated sleep time to prevent creating a Thundering Herd.
+
+### Fixed
+
+- Fixes a bug with negative times that could occur due to the small difference between local (client) time and Github server time. Sleep time is now calculated using the date header (time as seen by the Github server). Additionally, negative sleep times are prevented by setting a minimum sleep time equal to the jitter time.
+
 ## [v0.10.0] - 2023-04-28
+
+### Added
 
 - Implements retry logic for Github API HTTP requests. Cogito retries the HTTP request up to 3 times in case the Github user is rate limited. The maximum wait time between request is set to 15 minutes. Additionally, http requests with status codes 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout are retried. For these 5xx status codes the wait time between retries is set to 5 seconds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.10.1] - 2023-05-17
+## [v0.10.1] - 2023-05-31
 
 ### Added
 
-- Adds a jitter time to calculated sleep time to prevent creating a Thundering Herd.
+- Prevent being rate limited by GitHub: add a jitter time to calculated sleep time to prevent creating a Thundering Herd.
 
 ### Fixed
 
-- Fixes a bug with negative times that could occur due to the small difference between local (client) time and Github server time. Sleep time is now calculated using the date header (time as seen by the Github server). Additionally, negative sleep times are prevented by setting a minimum sleep time equal to the jitter time.
+- Prevent being rate limited by GitHub: fix a bug that caused a negative sleep time due to the clock difference between GitHub and the host running Cogito.
 
 ## [v0.10.0] - 2023-04-28
 

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -1,6 +1,7 @@
 package cogito
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/Pix4D/cogito/github"
@@ -38,6 +39,8 @@ func (sink GitHubCommitStatusSink) Send() error {
 		MaxRetries:   maxRetries,
 		WaitTime:     waitTime,
 		MaxSleepTime: maxSleepTime,
+		// adds some randomness to sleep time to prevent creating a Thundering Herd
+		Jitter: time.Duration(rand.Intn(30)) * time.Second,
 	}
 	commitStatus := github.NewCommitStatus(target, sink.Request.Source.AccessToken,
 		sink.Request.Source.Owner, sink.Request.Source.Repo, context, sink.Log)

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -39,8 +39,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 		MaxRetries:   maxRetries,
 		WaitTime:     waitTime,
 		MaxSleepTime: maxSleepTime,
-		// adds some randomness to sleep time to prevent creating a Thundering Herd
-		Jitter: time.Duration(rand.Intn(30)) * time.Second,
+		Jitter:       time.Duration(rand.Intn(30)) * time.Second,
 	}
 	commitStatus := github.NewCommitStatus(target, sink.Request.Source.AccessToken,
 		sink.Request.Source.Owner, sink.Request.Source.Repo, context, sink.Log)

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -181,20 +181,13 @@ func httpRequestDo(req *http.Request) (httpResponse, error) {
 	response.oauthInfo = fmt.Sprintf("X-Accepted-Oauth-Scopes: %v, X-Oauth-Scopes: %v",
 		resp.Header.Get("X-Accepted-Oauth-Scopes"), resp.Header.Get("X-Oauth-Scopes"))
 
-	if limit := resp.Header.Get("X-RateLimit-Remaining"); limit != "" {
-		v, err := strconv.Atoi(limit)
-		if err != nil {
-			return httpResponse{}, fmt.Errorf("failed to convert X-RateLimit-Remaining header: %s", err)
-		}
-		response.rateLimitRemaining = v
-	}
-	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
-		v, err := strconv.Atoi(reset)
-		if err != nil {
-			return httpResponse{}, fmt.Errorf("failed to convert X-RateLimit-Reset header: %s", err)
-		}
-		response.rateLimitReset = time.Unix(int64(v), 0)
-	}
+	// strconv.Atoi returns 0 in case of error, Get returns "" if empty (both are standard behaviors)
+	response.rateLimitRemaining, _ = strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
+
+	// strconv.Atoi returns 0 in case of error, Get returns "" if empty (both are standard behaviors)
+	limit, _ := strconv.Atoi(resp.Header.Get("X-RateLimit-Reset"))
+	response.rateLimitReset = time.Unix(int64(limit), 0)
+
 	// time.RFC1123 is the format of the HTTP Date header
 	// example: Date:[ Mon, 02 Jan 2006 15:04:05 MST ]
 	// https://datatracker.ietf.org/doc/html/rfc2616#section-14.18


### PR DESCRIPTION
- use date header reporting the server time to calculate the sleep time
- add a jitter time to calculated sleep time to prevent creating a Thundering Herd
- prevent negative sleep times. Minimal sleep time should be equal to jitter time
