### PR TITLE
fix: internal error: unexpected: negative sleep time: 0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED [v0.10.2] - 2023-XX-XX
 
+### Fixed
+
+- GitHub: fix: internal error: unexpected: negative sleep time: 0s
+
 ### Changed
 
 - GitHub: log the reason for retrying [#123](https://github.com/Pix4D/cogito/issues/123).
@@ -25,11 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Implements retry logic for Github API HTTP requests. Cogito retries the HTTP request up to 3 times in case the Github user is rate limited. The maximum wait time between request is set to 15 minutes. Additionally, http requests with status codes 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout are retried. For these 5xx status codes the wait time between retries is set to 5 seconds.
+- Implements retry logic for GitHub API HTTP requests. Cogito retries the HTTP request up to 3 times in case the GitHub user is rate limited. The maximum wait time between request is set to 15 minutes. Additionally, http requests with status codes 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout are retried. For these 5xx status codes the wait time between retries is set to 5 seconds.
 
 ## [v0.9.0] - 2023-03-16
 
-- This release allows to use cogito purely to send chat notifications, completely independently from GitHub. This allows to use cogito in place of concourse-hangouts-resource in any situation.
+- This release allows to use cogito purely to send chat notifications, completely independently of GitHub. This allows to use cogito in place of concourse-hangouts-resource in any situation.
 
 ### Added
 
@@ -37,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Configuring a GitHub repository is not mandatory any more, to allow cogito to be used purely for chat notification.
+- Configuring a GitHub repository is not mandatory anymore, to allow cogito to be used purely for chat notification.
 - Documentation addresses explicitly how to configure cogito based on the three possible use cases: GitHub only, GitHub + Chat, Chat only.
 
 ## [v0.8.2] - 2022-11-18

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -286,7 +286,7 @@ func checkForRetry(res httpResponse, waitTime, maxSleepTime, jitter time.Duratio
 
 		switch {
 		case sleepTime == 0:
-			return true, 0, "rate limited, server-side inconsistency, should retry"
+			return true, 0, "rate limited, should retry"
 		case sleepTime > maxSleepTime:
 			return false, 0, "rate limited, sleepTime > maxSleepTime, should not retry"
 		case sleepTime < maxSleepTime:

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -284,12 +284,10 @@ func checkForRetry(res httpResponse, waitTime, maxSleepTime, jitter time.Duratio
 		// Be a good netizen by adding some jitter to the time we sleep.
 		sleepTime += jitter
 
-		switch {
-		case sleepTime > maxSleepTime:
+		if sleepTime > maxSleepTime {
 			return false, 0, "rate limited, sleepTime > maxSleepTime, should not retry"
-		case sleepTime < maxSleepTime:
-			return true, sleepTime, "rate limited, should retry"
 		}
+		return true, sleepTime, "rate limited, should retry"
 	}
 
 	// Do we have a retryable HTTP status code ?

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -285,8 +285,6 @@ func checkForRetry(res httpResponse, waitTime, maxSleepTime, jitter time.Duratio
 		sleepTime += jitter
 
 		switch {
-		case sleepTime == 0:
-			return true, 0, "rate limited, should retry"
 		case sleepTime > maxSleepTime:
 			return false, 0, "rate limited, sleepTime > maxSleepTime, should not retry"
 		case sleepTime < maxSleepTime:

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -281,6 +281,8 @@ func checkForRetry(res httpResponse, waitTime, maxSleepTime, jitter time.Duratio
 		// Be a good netizen by adding some jitter to the time we sleep.
 		sleepTime += jitter
 		switch {
+		case sleepTime == 0:
+			return 0, "", nil
 		case sleepTime > maxSleepTime:
 			return 0, "", nil
 		case sleepTime > 0 && sleepTime < maxSleepTime:

--- a/github/commitstatus_private_test.go
+++ b/github/commitstatus_private_test.go
@@ -8,27 +8,27 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+const maxSleepTime = 15 * time.Minute
+
+var serverDate = time.Date(2001, time.April, 30, 13, 0, 0, 0, time.UTC)
+
 func TestCheckForRetrySuccess(t *testing.T) {
 	type testCase struct {
-		name         string
-		res          httpResponse
-		waitTime     time.Duration
-		maxSleepTime time.Duration
-		jitter       time.Duration
-		wantSleep    time.Duration
-		wantReason   string
+		name       string
+		res        httpResponse
+		waitTime   time.Duration
+		jitter     time.Duration
+		wantSleep  time.Duration
+		wantReason string
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		sleep, reason, err := checkForRetry(tc.res, tc.waitTime, tc.maxSleepTime, tc.jitter)
+		sleep, reason, err := checkForRetry(tc.res, tc.waitTime, maxSleepTime, tc.jitter)
 
 		assert.NilError(t, err)
 		assert.Equal(t, sleep, tc.wantSleep)
 		assert.Equal(t, reason, tc.wantReason)
 	}
-
-	serverDate := time.Date(2001, time.April, 30, 13, 0, 0, 0, time.UTC)
-	const maxSleepTime = 15 * time.Minute
 
 	testCases := []testCase{
 		{
@@ -55,8 +55,7 @@ func TestCheckForRetrySuccess(t *testing.T) {
 				date:           serverDate,
 				rateLimitReset: serverDate.Add(30 * time.Minute),
 			},
-			maxSleepTime: maxSleepTime,
-			wantSleep:    0 * time.Second,
+			wantSleep: 0 * time.Second,
 		},
 		{
 			name: "rate limited, would sleep a bit, adding also the jitter",
@@ -65,10 +64,9 @@ func TestCheckForRetrySuccess(t *testing.T) {
 				date:           serverDate,
 				rateLimitReset: serverDate.Add(5 * time.Minute),
 			},
-			maxSleepTime: maxSleepTime,
-			jitter:       8 * time.Second,
-			wantSleep:    5*time.Minute + 8*time.Second,
-			wantReason:   "rate limited",
+			jitter:     8 * time.Second,
+			wantSleep:  5*time.Minute + 8*time.Second,
+			wantReason: "rate limited",
 		},
 	}
 

--- a/github/commitstatus_private_test.go
+++ b/github/commitstatus_private_test.go
@@ -109,3 +109,7 @@ func TestCheckForRetry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) { run(t, tc) })
 	}
 }
+
+// This is now clearly visible in the SUT. Will make another PR.
+// BUG: sleeptime + jitter might cause a failure; test sleepTime > maxSleepTime should
+// be done before?

--- a/github/commitstatus_private_test.go
+++ b/github/commitstatus_private_test.go
@@ -86,7 +86,7 @@ func TestCheckForRetry(t *testing.T) {
 			},
 			// Since we set jitter from rand.Intn, which can return 0, jitter can be 0.
 			jitter:     0 * time.Second,
-			wantReason: "rate limited, server-side inconsistency, should retry",
+			wantReason: "rate limited, should retry",
 			wantRetry:  true,
 		},
 		{

--- a/github/commitstatus_private_test.go
+++ b/github/commitstatus_private_test.go
@@ -8,12 +8,13 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestCheckForRetrySuccess(t *testing.T) {
+func TestCheckForRetry(t *testing.T) {
 	type testCase struct {
 		name       string
 		res        httpResponse
 		waitTime   time.Duration
 		jitter     time.Duration
+		wantRetry  bool
 		wantSleep  time.Duration
 		wantReason string
 	}
@@ -22,49 +23,56 @@ func TestCheckForRetrySuccess(t *testing.T) {
 	var serverDate = time.Date(2001, time.April, 30, 13, 0, 0, 0, time.UTC)
 
 	run := func(t *testing.T, tc testCase) {
-		sleep, reason := checkForRetry(tc.res, tc.waitTime, maxSleepTime, tc.jitter)
+		retry, sleep, reason := checkForRetry(
+			tc.res, tc.waitTime, maxSleepTime, tc.jitter)
 
+		assert.Equal(t, retry, tc.wantRetry)
 		assert.Equal(t, sleep, tc.wantSleep)
 		assert.Equal(t, reason, tc.wantReason)
 	}
 
 	testCases := []testCase{
 		{
-			name:      "status OK: sleep==0",
-			res:       httpResponse{statusCode: http.StatusOK},
-			wantSleep: 0 * time.Second,
+			name:       "status OK: do not retry",
+			res:        httpResponse{statusCode: http.StatusOK},
+			wantRetry:  false,
+			wantReason: "no retryable reasons",
 		},
 		{
-			name:      "non retryable status code: sleep==0",
-			res:       httpResponse{statusCode: http.StatusTeapot},
-			wantSleep: 0 * time.Second,
+			name:       "non retryable status code: do not retry",
+			res:        httpResponse{statusCode: http.StatusTeapot},
+			wantReason: "no retryable reasons",
+			wantRetry:  false,
 		},
 		{
-			name:       "retryable status code: sleep==waitTime",
+			name:       "retryable status code: retry, sleep==waitTime",
 			res:        httpResponse{statusCode: http.StatusInternalServerError},
 			waitTime:   42 * time.Second,
+			wantRetry:  true,
 			wantSleep:  42 * time.Second,
 			wantReason: "Internal Server Error",
 		},
 		{
-			name: "rate limited, would sleep too long: sleep==0",
+			name: "rate limited, would sleep too long: do not retry",
 			res: httpResponse{
 				statusCode:     http.StatusForbidden,
 				date:           serverDate,
 				rateLimitReset: serverDate.Add(30 * time.Minute),
 			},
-			wantSleep: 0 * time.Second,
+			wantReason: "rate limited, sleepTime > maxSleepTime, should not retry",
+			wantRetry:  false,
 		},
 		{
-			name: "rate limited, would sleep a bit, adding also the jitter",
+			name: "rate limited, do retry, sleep adding also the jitter",
 			res: httpResponse{
 				statusCode:     http.StatusForbidden,
 				date:           serverDate,
 				rateLimitReset: serverDate.Add(5 * time.Minute),
 			},
 			jitter:     8 * time.Second,
+			wantRetry:  true,
 			wantSleep:  5*time.Minute + 8*time.Second,
-			wantReason: "rate limited",
+			wantReason: "rate limited, should retry",
 		},
 		{
 			// Fix https://github.com/Pix4D/cogito/issues/124
@@ -77,7 +85,9 @@ func TestCheckForRetrySuccess(t *testing.T) {
 				rateLimitReset: serverDate,
 			},
 			// Since we set jitter from rand.Intn, which can return 0, jitter can be 0.
-			jitter: 0 * time.Second,
+			jitter:     0 * time.Second,
+			wantReason: "rate limited, server-side inconsistency, should retry",
+			wantRetry:  true,
 		},
 		{
 			name: "robust against server date after rateLimitReset",
@@ -89,8 +99,9 @@ func TestCheckForRetrySuccess(t *testing.T) {
 				rateLimitReset: serverDate.Add(-2 * time.Second),
 			},
 			jitter:     1 * time.Second,
+			wantRetry:  true,
 			wantSleep:  1 * time.Second,
-			wantReason: "rate limited",
+			wantReason: "rate limited, should retry",
 		},
 	}
 

--- a/github/commitstatus_private_test.go
+++ b/github/commitstatus_private_test.go
@@ -22,9 +22,8 @@ func TestCheckForRetrySuccess(t *testing.T) {
 	var serverDate = time.Date(2001, time.April, 30, 13, 0, 0, 0, time.UTC)
 
 	run := func(t *testing.T, tc testCase) {
-		sleep, reason, err := checkForRetry(tc.res, tc.waitTime, maxSleepTime, tc.jitter)
+		sleep, reason := checkForRetry(tc.res, tc.waitTime, maxSleepTime, tc.jitter)
 
-		assert.NilError(t, err)
 		assert.Equal(t, sleep, tc.wantSleep)
 		assert.Equal(t, reason, tc.wantReason)
 	}

--- a/github/commitstatus_private_test.go
+++ b/github/commitstatus_private_test.go
@@ -77,3 +77,62 @@ func TestCheckForRetrySuccess(t *testing.T) {
 
 // BUG: sleeptime + jitter might cause a failure; test sleepTime > maxSleepTime should
 // be done before?
+
+// We saw this happening in production. Since we didn't have debug logging, we cannot
+// be sure of the cause, so we show two possible causes in the test cases.
+func TestCheckForRetryNegativeSleepTime(t *testing.T) {
+	type testCase struct {
+		name    string
+		res     httpResponse
+		jitter  time.Duration
+		wantErr string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		// Not in the code path, no effect.
+		waitTime := 0 * time.Second
+
+		_, _, err := checkForRetry(tc.res, waitTime, maxSleepTime, tc.jitter)
+
+		assert.Error(t, err, tc.wantErr)
+	}
+
+	testCases := []testCase{
+		{
+			// BUG
+			// This actually shows a bug in the code, since in this case the sleep time
+			// is 0, not negative, and everything would have worked as expected if we
+			// did not return an error.
+			// Of the two test cases, this is probably what we encountered, because
+			// the error was "negative sleep time: 0s", while 0 is not negative.
+			name: "same server date and rateLimitReset, zero jitter",
+			// Same server date and rateLimitReset.
+			// This can be explained by a benign race in the backend.
+			res: httpResponse{
+				statusCode:     http.StatusForbidden,
+				date:           serverDate,
+				rateLimitReset: serverDate,
+			},
+			// Since we set jitter from rand.Intn, which can return 0, jitter can be 0.
+			jitter:  0 * time.Second,
+			wantErr: "unexpected: negative sleep time: 0s",
+		},
+		{
+			name: "server date slightly after rateLimitReset, too small jitter",
+			// Server date slightly after rateLimitReset.
+			// This can be explained by a benign race in the backend.
+			res: httpResponse{
+				statusCode:     http.StatusForbidden,
+				date:           serverDate,
+				rateLimitReset: serverDate.Add(-2 * time.Second),
+			},
+			// Too small jitter.
+			jitter:  1 * time.Second,
+			wantErr: "unexpected: negative sleep time: -1s",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { run(t, tc) })
+	}
+}

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -96,6 +96,25 @@ func TestGitHubStatusSuccessMockAPI(t *testing.T) {
 			},
 		},
 		{
+			name: "retry also on server-side inconsistency (zero or negative sleep time), repro of Pix4D/cogito#124",
+			response: []mockedResponse{
+				{
+					status:             http.StatusForbidden,
+					rateLimitRemaining: emptyRateRemaining,
+					// This causes sleep time to be 0: it would be silly to fail,
+					// we should instead attempt once more. Depending on the problem
+					// server-side, the next request might also fail, but at least we
+					// did everything we could.
+					rateLimitReset: now.Unix(),
+				},
+				{
+					status:             http.StatusCreated,
+					rateLimitRemaining: fullRateRemaining,
+					rateLimitReset:     now.Add(1 * time.Hour).Unix(),
+				},
+			},
+		},
+		{
 			name: "Github is flaky (Gateway timeout) at the first attempt, success at second attempt",
 			response: []mockedResponse{
 				{


### PR DESCRIPTION
Closes #124 and PCI-3302.

Best reviewed commit-per-commit and looking at the commit comments, otherwise it will be impossible to understand the details, and we do need to understand them in this case. Each commit tells the story and carefully builds on the precedent, keeping code coverage 100% (this doesn't ensure anything but is better than not doing it).

Last commit is perhaps the most unexpected, were we "define the errror out of existence", in the spirit of the book "A Philosophy of Software Design" by John Ousterhout (Talk: https://youtu.be/bmSAYlu0NcY?t=1313).

I have a recollection that the reason for the existence of the error is a comment I made on a previous PR by Aleksandar, so I am undoing what I proposed, because I learned from experience.

I decided not to touch the jitter initialization on purpose, because I think that the code in this PR is more robust and still as simple as it can. I am open to discussion.

