### PR TITLE
fix #132: does not sleep when it should, approach 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.10.3] - 2023-08-XX
+
+### Fixed
+
+- Retry GitHub HTTP request when rate limited: the fix for [#124](https://github.com/Pix4D/cogito/issues/124) introduced a new bug. This fixes it. 
+
 ## [v0.10.2] - 2023-07-28
 
 ### Fixed
 
-- Retry GitHub HTTP request when rate limited: fix internal error: unexpected: negative sleep time: 0s
+- Retry GitHub HTTP request when rate limited: fix internal error: unexpected: negative sleep time: 0s [#124](https://github.com/Pix4D/cogito/issues/124).
 
 ### Changed
 

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -112,10 +112,8 @@ func (s CommitStatus) Add(sha, state, targetURL, description string) error {
 	req.Header.Set("Content-Type", "application/json")
 
 	var response httpResponse
-	timeToSleep := 0 * time.Second
 
 	for attempt := 1; attempt <= s.target.MaxRetries; attempt++ {
-		time.Sleep(timeToSleep)
 		s.log.Info("GitHub HTTP request", "attempt", attempt, "max", s.target.MaxRetries)
 		response, err = httpRequestDo(req)
 		if err != nil {
@@ -127,6 +125,7 @@ func (s CommitStatus) Add(sha, state, targetURL, description string) error {
 			break
 		}
 		s.log.Info("Sleeping for", "duration", timeToSleep, "reason", reason)
+		time.Sleep(timeToSleep)
 	}
 
 	return s.checkStatus(response, state, sha, url)


### PR DESCRIPTION
As mentioned, this is approach 1 at fixing #132. See also approach 2 at #134.

It works, but it makes the test to take longer (as they were taking before I added this bug) and is somehow flaky, since it is obliged to measure time, and time can skew based on CI load.

Best reviewed commit-per-commit, since commit 1 adds the repro and commit 2 adds the fix.

Fixes #132.