### PR TITLE
PCI-3363 add support for Github Enterprise API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.12.0] - Unreleased
+
+### Added 
+
+- `source.github_api_endpoint`: override the default API endpoint. This allows you to post commit statuses to repositories hosted by GitHub Enterprise (GHE) instances. When provided, this parameter must be a valid HTTPS URL.
+
 ## [v0.11.0] - 2023-09-22
 
 ### Added 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
   The log level (one of `debug`, `info`, `warn`, `error`, `silent`).\
   Default: `info`.
 
+- `github_api_endpoint`:\
+  Override the default API endpoint. This allows you to post commit statuses to repositories hosted by GitHub Enterprise (GHE) instances. When provided, this parameter must be a valid https url.
+  Default: `https://api.github.com`
+
 - `log_url`. **DEPRECATED, no-op, will be removed**\
   A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < v7.x
 

--- a/cmd/cogito/main.go
+++ b/cmd/cogito/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/Pix4D/cogito/cogito"
-	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/sets"
 )
 
@@ -56,7 +55,7 @@ func mainErr(in io.Reader, out io.Writer, logOut io.Writer, args []string) error
 	case "in":
 		return cogito.Get(log, input, out, args[1:])
 	case "out":
-		putter := cogito.NewPutter(github.API, log)
+		putter := cogito.NewPutter(log)
 		return cogito.Put(input, out, args[1:], putter)
 	default:
 		return fmt.Errorf("cli wiring error; please report")

--- a/cmd/cogito/main.go
+++ b/cmd/cogito/main.go
@@ -50,21 +50,14 @@ func mainErr(in io.Reader, out io.Writer, logOut io.Writer, args []string) error
 	})
 	log.Info(cogito.BuildInfo())
 
-	ghAPI := os.Getenv("COGITO_GITHUB_API")
-	if ghAPI != "" {
-		log.Info("endpoint override", "COGITO_GITHUB_API", ghAPI)
-	} else {
-		ghAPI = github.API
-	}
-
 	switch cmd {
 	case "check":
 		return cogito.Check(log, input, out, args[1:])
 	case "in":
 		return cogito.Get(log, input, out, args[1:])
 	case "out":
-		putter := cogito.NewPutter(ghAPI, log)
-		return cogito.Put(log, input, out, args[1:], putter)
+		putter := cogito.NewPutter(github.API, log)
+		return cogito.Put(input, out, args[1:], putter)
 	default:
 		return fmt.Errorf("cli wiring error; please report")
 	}

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -67,6 +67,11 @@ func TestRunPutSuccess(t *testing.T) {
 	chatReply := googlechat.MessageReply{}
 	var gchatUrl *url.URL
 	googleChatSpy := testhelp.SpyHttpServer(&chatMsg, chatReply, &gchatUrl, http.StatusOK)
+	gitHubSpyDomain, err := url.Parse(gitHubSpy.URL)
+	if err != nil {
+		t.Fatalf("error parsing SpyHttpServer URL: %s", err)
+	}
+
 	in := bytes.NewReader(testhelp.ToJSON(t, cogito.PutRequest{
 		Source: cogito.Source{
 			Owner:             "the-owner",
@@ -81,9 +86,9 @@ func TestRunPutSuccess(t *testing.T) {
 	var out bytes.Buffer
 	var logOut bytes.Buffer
 	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
-		testhelp.HttpsRemote("the-owner", "the-repo"), "dummySHA", wantGitRef)
+		testhelp.HttpsRemote(gitHubSpyDomain.Host, "the-owner", "the-repo"), "dummySHA", wantGitRef)
 
-	err := mainErr(in, &out, &logOut, []string{"out", inputDir})
+	err = mainErr(in, &out, &logOut, []string{"out", inputDir})
 
 	assert.NilError(t, err, "\nout: %s\nlogOut: %s", out.String(), logOut.String())
 	//
@@ -115,7 +120,7 @@ func TestRunPutSuccessIntegration(t *testing.T) {
 	var out bytes.Buffer
 	var logOut bytes.Buffer
 	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
-		testhelp.HttpsRemote(gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
+		testhelp.HttpsRemote("github.com", gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
 		"ref: refs/heads/a-branch-FIXME")
 	t.Setenv("BUILD_JOB_NAME", "TestRunPutSuccessIntegration")
 	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.invalid")

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -69,11 +69,12 @@ func TestRunPutSuccess(t *testing.T) {
 	googleChatSpy := testhelp.SpyHttpServer(&chatMsg, chatReply, &gchatUrl, http.StatusOK)
 	in := bytes.NewReader(testhelp.ToJSON(t, cogito.PutRequest{
 		Source: cogito.Source{
-			Owner:        "the-owner",
-			Repo:         "the-repo",
-			AccessToken:  "the-secret",
-			GChatWebHook: googleChatSpy.URL,
-			LogLevel:     "debug",
+			Owner:             "the-owner",
+			Repo:              "the-repo",
+			AccessToken:       "the-secret",
+			GithubApiEndpoint: gitHubSpy.URL,
+			GChatWebHook:      googleChatSpy.URL,
+			LogLevel:          "debug",
 		},
 		Params: cogito.PutParams{State: wantState},
 	}))
@@ -81,7 +82,6 @@ func TestRunPutSuccess(t *testing.T) {
 	var logOut bytes.Buffer
 	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
 		testhelp.HttpsRemote("the-owner", "the-repo"), "dummySHA", wantGitRef)
-	t.Setenv("COGITO_GITHUB_API", gitHubSpy.URL)
 
 	err := mainErr(in, &out, &logOut, []string{"out", inputDir})
 

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -58,6 +58,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 		"state", ghState, "owner", sink.Request.Source.Owner,
 		"repo", sink.Request.Source.Repo, "git-ref", sink.GitRef,
 		"context", context, "buildURL", buildURL, "description", description)
+
 	if err := commitStatus.Add(sink.GitRef, ghState, buildURL, description); err != nil {
 		return err
 	}

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -27,7 +27,6 @@ const (
 // GitHubCommitStatusSink is an implementation of [Sinker] for the Cogito resource.
 type GitHubCommitStatusSink struct {
 	Log     hclog.Logger
-	GhAPI   string
 	GitRef  string
 	Request PutRequest
 }
@@ -42,7 +41,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 	context := ghMakeContext(sink.Request)
 
 	target := &github.Target{
-		Server: sink.GhAPI,
+		Server: sink.Request.Source.GithubApiEndpoint,
 		Retry: retry.Retry{
 			FirstDelay:   retryFirstDelay,
 			BackoffLimit: retryBackoffLimit,
@@ -58,7 +57,6 @@ func (sink GitHubCommitStatusSink) Send() error {
 		"state", ghState, "owner", sink.Request.Source.Owner,
 		"repo", sink.Request.Source.Repo, "git-ref", sink.GitRef,
 		"context", context, "buildURL", buildURL, "description", description)
-
 	if err := commitStatus.Add(sink.GitRef, ghState, buildURL, description); err != nil {
 		return err
 	}

--- a/cogito/ghcommitsink_test.go
+++ b/cogito/ghcommitsink_test.go
@@ -25,9 +25,9 @@ func TestSinkGitHubCommitStatusSendSuccess(t *testing.T) {
 	ts := testhelp.SpyHttpServer(&ghReq, nil, &URL, http.StatusCreated)
 	sink := cogito.GitHubCommitStatusSink{
 		Log:    hclog.NewNullLogger(),
-		GhAPI:  ts.URL,
 		GitRef: wantGitRef,
 		Request: cogito.PutRequest{
+			Source: cogito.Source{GithubApiEndpoint: ts.URL},
 			Params: cogito.PutParams{State: wantState},
 			Env:    cogito.Environment{BuildJobName: jobName},
 		},
@@ -50,9 +50,9 @@ func TestSinkGitHubCommitStatusSendFailure(t *testing.T) {
 	defer ts.Close()
 	sink := cogito.GitHubCommitStatusSink{
 		Log:    hclog.NewNullLogger(),
-		GhAPI:  ts.URL,
 		GitRef: "deadbeefdeadbeef",
 		Request: cogito.PutRequest{
+			Source: cogito.Source{GithubApiEndpoint: ts.URL},
 			Params: cogito.PutParams{State: cogito.StatePending},
 		},
 	}

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/sets"
 )
 
@@ -165,6 +166,7 @@ type Source struct {
 	//
 	// Optional
 	//
+	GithubApiEndpoint  string       `json:"github_api_endpoint"`
 	GChatWebHook       string       `json:"gchat_webhook"` // SENSITIVE
 	LogLevel           string       `json:"log_level"`
 	LogUrl             string       `json:"log_url"` // DEPRECATED
@@ -172,7 +174,6 @@ type Source struct {
 	ChatAppendSummary  bool         `json:"chat_append_summary"`
 	ChatNotifyOnStates []BuildState `json:"chat_notify_on_states"`
 	Sinks              []string     `json:"sinks"`
-	GithubApiEndpoint  string       `json:"github_api_endpoint"`
 }
 
 // String renders Source, redacting the sensitive fields.
@@ -181,6 +182,7 @@ func (src Source) String() string {
 
 	fmt.Fprintf(&bld, "owner:                 %s\n", src.Owner)
 	fmt.Fprintf(&bld, "repo:                  %s\n", src.Repo)
+	fmt.Fprintf(&bld, "github_api_endpoint:   %s\n", src.GithubApiEndpoint)
 	fmt.Fprintf(&bld, "access_token:          %s\n", redact(src.AccessToken))
 	fmt.Fprintf(&bld, "gchat_webhook:         %s\n", redact(src.GChatWebHook))
 	fmt.Fprintf(&bld, "log_level:             %s\n", src.LogLevel)
@@ -188,8 +190,7 @@ func (src Source) String() string {
 	fmt.Fprintf(&bld, "chat_append_summary:   %t\n", src.ChatAppendSummary)
 	fmt.Fprintf(&bld, "chat_notify_on_states: %s\n", src.ChatNotifyOnStates)
 	// Last one: no newline.
-	fmt.Fprintf(&bld, "sinks: %s\n", src.Sinks)
-	fmt.Fprintf(&bld, "github_api_endpoint: %s", src.GithubApiEndpoint)
+	fmt.Fprintf(&bld, "sinks: %s", src.Sinks)
 
 	return bld.String()
 }
@@ -257,7 +258,9 @@ func (src *Source) Validate() error {
 		return fmt.Errorf("source: missing keys: %s", strings.Join(mandatory, ", "))
 	}
 
+	//
 	// Validate optional fields.
+	//
 	if src.GithubApiEndpoint != "" {
 		u, err := url.ParseRequestURI(src.GithubApiEndpoint)
 		if err != nil || u.Host == "" {
@@ -273,6 +276,9 @@ func (src *Source) Validate() error {
 	}
 	if len(src.ChatNotifyOnStates) == 0 {
 		src.ChatNotifyOnStates = defaultNotifyStates
+	}
+	if len(src.GithubApiEndpoint) == 0 {
+		src.GithubApiEndpoint = github.API
 	}
 
 	return nil

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -171,6 +172,7 @@ type Source struct {
 	ChatAppendSummary  bool         `json:"chat_append_summary"`
 	ChatNotifyOnStates []BuildState `json:"chat_notify_on_states"`
 	Sinks              []string     `json:"sinks"`
+	GithubApiEndpoint  string       `json:"github_api_endpoint"`
 }
 
 // String renders Source, redacting the sensitive fields.
@@ -186,7 +188,8 @@ func (src Source) String() string {
 	fmt.Fprintf(&bld, "chat_append_summary:   %t\n", src.ChatAppendSummary)
 	fmt.Fprintf(&bld, "chat_notify_on_states: %s\n", src.ChatNotifyOnStates)
 	// Last one: no newline.
-	fmt.Fprintf(&bld, "sinks: %s", src.Sinks)
+	fmt.Fprintf(&bld, "sinks: %s\n", src.Sinks)
+	fmt.Fprintf(&bld, "github_api_endpoint: %s", src.GithubApiEndpoint)
 
 	return bld.String()
 }
@@ -254,10 +257,13 @@ func (src *Source) Validate() error {
 		return fmt.Errorf("source: missing keys: %s", strings.Join(mandatory, ", "))
 	}
 
-	//
 	// Validate optional fields.
-	//
-	// In this case, nothing to validate.
+	if src.GithubApiEndpoint != "" {
+		u, err := url.ParseRequestURI(src.GithubApiEndpoint)
+		if err != nil || u.Host == "" {
+			return fmt.Errorf("source: github_api_endpoint '%s' is an invalid api endpoint", src.GithubApiEndpoint)
+		}
+	}
 
 	//
 	// Apply defaults.

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -213,6 +213,7 @@ func TestSourcePrintLogRedaction(t *testing.T) {
 	source := cogito.Source{
 		Owner:              "the-owner",
 		Repo:               "the-repo",
+		GithubApiEndpoint:  "dummy-api",
 		AccessToken:        "sensitive-the-access-token",
 		GChatWebHook:       "sensitive-gchat-webhook",
 		LogLevel:           "debug",
@@ -224,14 +225,14 @@ func TestSourcePrintLogRedaction(t *testing.T) {
 	t.Run("fmt.Print redacts fields", func(t *testing.T) {
 		want := `owner:                 the-owner
 repo:                  the-repo
+github_api_endpoint:   dummy-api
 access_token:          ***REDACTED***
 gchat_webhook:         ***REDACTED***
 log_level:             debug
 context_prefix:        the-prefix
 chat_append_summary:   true
 chat_notify_on_states: [success failure]
-sinks: []
-github_api_endpoint: `
+sinks: []`
 
 		have := fmt.Sprint(source)
 
@@ -244,14 +245,14 @@ github_api_endpoint: `
 		}
 		want := `owner:                 the-owner
 repo:                  
+github_api_endpoint:   
 access_token:          
 gchat_webhook:         
 log_level:             
 context_prefix:        
 chat_append_summary:   false
 chat_notify_on_states: []
-sinks: []
-github_api_endpoint: `
+sinks: []`
 
 		have := fmt.Sprint(input)
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -46,6 +46,14 @@ func TestSourceValidationSuccess(t *testing.T) {
 				return source
 			},
 		},
+		{
+			name: "optional git source github_api_endpoint",
+			mkSource: func() cogito.Source {
+				source := baseGithubSource
+				source.GithubApiEndpoint = "https://github.coffee.com/api/v3"
+				return source
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -101,6 +109,36 @@ func TestSourceValidationFailure(t *testing.T) {
 				AccessToken:  "the-token",
 			},
 			wantErr: "source: invalid sink(s): [closed coffee shop]",
+		},
+		{
+			name: "no protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:             "the-owner",
+				Repo:              "the-repo",
+				AccessToken:       "the-token",
+				GithubApiEndpoint: "github.coffee.com/api/v3",
+			},
+			wantErr: "source: github_api_endpoint 'github.coffee.com/api/v3' is an invalid api endpoint",
+		},
+		{
+			name: "invalid http protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:             "the-owner",
+				Repo:              "the-repo",
+				AccessToken:       "the-token",
+				GithubApiEndpoint: "https:github.coffee.com/api/v3",
+			},
+			wantErr: "source: github_api_endpoint 'https:github.coffee.com/api/v3' is an invalid api endpoint",
+		},
+		{
+			name: "invalid http protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:             "the-owner",
+				Repo:              "the-repo",
+				AccessToken:       "the-token",
+				GithubApiEndpoint: "john.smith.cim",
+			},
+			wantErr: "source: github_api_endpoint 'john.smith.cim' is an invalid api endpoint",
 		},
 	}
 
@@ -192,7 +230,8 @@ log_level:             debug
 context_prefix:        the-prefix
 chat_append_summary:   true
 chat_notify_on_states: [success failure]
-sinks: []`
+sinks: []
+github_api_endpoint: `
 
 		have := fmt.Sprint(source)
 
@@ -211,7 +250,8 @@ log_level:
 context_prefix:        
 chat_append_summary:   false
 chat_notify_on_states: []
-sinks: []`
+sinks: []
+github_api_endpoint: `
 
 		have := fmt.Sprint(input)
 

--- a/cogito/put.go
+++ b/cogito/put.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/hashicorp/go-hclog"
 )
 
 // Putter represents the put step of a Concourse resource.
@@ -40,7 +38,7 @@ type Sinker interface {
 // Additionally, the script may emit metadata as a list of key-value pairs. This data is
 // intended for public consumption and will make it upstream, intended to be shown on the
 // build's page.
-func Put(log hclog.Logger, input []byte, out io.Writer, args []string, putter Putter) error {
+func Put(input []byte, out io.Writer, args []string, putter Putter) error {
 	if err := putter.LoadConfiguration(input, args); err != nil {
 		return fmt.Errorf("put: %s", err)
 	}

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -152,10 +152,12 @@ func (putter *ProdPutter) ProcessInputDir() error {
 }
 
 func (putter *ProdPutter) Sinks() []Sinker {
+	source := putter.Request.Source
+	ghApiEndpoint := getEndpointFromSourceOrDefault(putter, source)
 	supportedSinkers := map[string]Sinker{
 		"github": GitHubCommitStatusSink{
 			Log:     putter.log.Named("ghCommitStatus"),
-			GhAPI:   putter.ghAPI,
+			GhAPI:   ghApiEndpoint,
 			GitRef:  putter.gitRef,
 			Request: putter.Request,
 		},
@@ -167,9 +169,9 @@ func (putter *ProdPutter) Sinks() []Sinker {
 			Request:  putter.Request,
 		},
 	}
-	source := putter.Request.Source.Sinks
+	sourceSinks := source.Sinks
 	params := putter.Request.Params.Sinks
-	sinks, _ := MergeAndValidateSinks(source, params)
+	sinks, _ := MergeAndValidateSinks(sourceSinks, params)
 
 	sinkers := make([]Sinker, 0, sinks.Size())
 	for _, s := range sinks.OrderedList() {
@@ -177,6 +179,15 @@ func (putter *ProdPutter) Sinks() []Sinker {
 	}
 
 	return sinkers
+}
+
+func getEndpointFromSourceOrDefault(putter *ProdPutter, source Source) string {
+	if source.GithubApiEndpoint != "" {
+		return source.GithubApiEndpoint
+	} else {
+		// the default
+		return putter.ghAPI
+	}
 }
 
 func (putter *ProdPutter) Output(out io.Writer) error {
@@ -262,8 +273,9 @@ func checkGitRepoDir(dir, owner, repo string) error {
 	if err != nil {
 		return fmt.Errorf(".git/config: remote: %w", err)
 	}
-	left := []string{"github.com", owner, repo}
-	right := []string{gu.URL.Host, gu.Owner, gu.Repo}
+
+	left := []string{owner, repo}
+	right := []string{gu.Owner, gu.Repo}
 	for i, l := range left {
 		r := right[i]
 		if !strings.EqualFold(l, r) {

--- a/cogito/putter_private_test.go
+++ b/cogito/putter_private_test.go
@@ -2,6 +2,7 @@ package cogito
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/testhelp"
 )
 
@@ -65,6 +67,7 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 		repoURL string
 	}
 
+	const wantDomain = "github.com"
 	const wantOwner = "smiling"
 	const wantRepo = "butterfly"
 
@@ -73,7 +76,7 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 			"dummySHA", "dummyHead")
 
 		err := checkGitRepoDir(filepath.Join(inputDir, filepath.Base(tc.dir)),
-			wantOwner, wantRepo)
+			github.API, wantOwner, wantRepo)
 
 		assert.NilError(t, err)
 	}
@@ -82,22 +85,22 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 		{
 			name:    "repo with good SSH remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.SshRemote(wantOwner, wantRepo),
+			repoURL: testhelp.SshRemote(wantDomain, wantOwner, wantRepo),
 		},
 		{
 			name:    "repo with good HTTPS remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpsRemote(wantOwner, wantRepo),
+			repoURL: testhelp.HttpsRemote(wantDomain, wantOwner, wantRepo),
 		},
 		{
 			name:    "repo with good HTTP remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpRemote(wantOwner, wantRepo),
+			repoURL: testhelp.HttpRemote(wantDomain, wantOwner, wantRepo),
 		},
 		{
 			name:    "PR resource but with basic auth in URL (see PR #46)",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: "https://x-oauth-basic:ghp_XXX@github.com/smiling/butterfly.git",
+			repoURL: fmt.Sprintf("https://x-oauth-basic:ghp_XXX@%s/%s/%s.git", wantDomain, wantOwner, wantRepo),
 		},
 	}
 
@@ -122,7 +125,7 @@ func TestCheckGitRepoDirFailure(t *testing.T) {
 			"dummySHA", "dummyHead")
 
 		err := checkGitRepoDir(filepath.Join(inDir, filepath.Base(tc.dir)),
-			wantOwner, wantRepo)
+			github.API, wantOwner, wantRepo)
 
 		assert.ErrorContains(t, err, tc.wantErrWild)
 	}
@@ -143,32 +146,34 @@ func TestCheckGitRepoDirFailure(t *testing.T) {
 		{
 			name:    "repo with unrelated HTTPS remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpsRemote("owner-a", "repo-a"),
+			repoURL: testhelp.HttpsRemote("github.com", "owner-a", "repo-a"),
 			wantErrWild: `the received git repository is incompatible with the Cogito configuration.
 
 Git repository configuration (received as 'inputs:' in this PUT step):
-      url: https://github.com/owner-a/repo-a.git
+    url: https://github.com/owner-a/repo-a.git
     owner: owner-a
-     repo: repo-a
+    repo: repo-a
 
 Cogito SOURCE configuration:
+    github_api_endpoint: https://api.github.com
     owner: smiling
-     repo: butterfly`,
+    repo: butterfly`,
 		},
 		{
 			name:    "repo with unrelated SSH remote or wrong source config",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.SshRemote("owner-a", "repo-a"),
+			repoURL: testhelp.SshRemote("github.com", "owner-a", "repo-a"),
 			wantErrWild: `the received git repository is incompatible with the Cogito configuration.
 
 Git repository configuration (received as 'inputs:' in this PUT step):
-      url: git@github.com:owner-a/repo-a.git
+    url: git@github.com:owner-a/repo-a.git
     owner: owner-a
-     repo: repo-a
+    repo: repo-a
 
 Cogito SOURCE configuration:
+    github_api_endpoint: https://api.github.com
     owner: smiling
-     repo: butterfly`,
+    repo: butterfly`,
 		},
 		{
 			name:        "invalid git pseudo URL in .git/config",

--- a/testhelp/testhelper.go
+++ b/testhelp/testhelper.go
@@ -247,18 +247,18 @@ func MakeGitRepoFromTestdata(
 }
 
 // SshRemote returns a GitHub SSH URL
-func SshRemote(owner, repo string) string {
-	return fmt.Sprintf("git@github.com:%s/%s.git", owner, repo)
+func SshRemote(domain, owner, repo string) string {
+	return fmt.Sprintf("git@%s:%s/%s.git", domain, owner, repo)
 }
 
 // HttpsRemote returns a GitHub HTTPS URL
-func HttpsRemote(owner, repo string) string {
-	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+func HttpsRemote(domain, owner, repo string) string {
+	return fmt.Sprintf("https://%s/%s/%s.git", domain, owner, repo)
 }
 
 // HttpRemote returns a GitHub HTTP URL
-func HttpRemote(owner, repo string) string {
-	return fmt.Sprintf("http://github.com/%s/%s.git", owner, repo)
+func HttpRemote(domain, owner, repo string) string {
+	return fmt.Sprintf("http://%s/%s/%s.git", domain, owner, repo)
 }
 
 // ToJSON returns the JSON encoding of thing.


### PR DESCRIPTION
Based on: https://github.com/Pix4D/cogito/pull/139

The first commit is a squashed commit of all commits present in the above PR. Credits are given to both authors: @wanderanimrod and @dev-jin

The second commit simplifies a bit their work and it's basically a cleanup of the `GhAPI` field from top-level code. There was no need to keep using both `GhAPI` and `GithubApiEndpoint`. 

While on it, I tried cleanup a bit the helper functions to prevent the unwanted bugs due to hardcoding `github.com` domain.

