### PR TITLE
PCI-3363 don't hardcode GitHub domain name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.12.0] - Unreleased
+
+### Added
+
+- Support GitHub Enterprise (see `source.github_hostname` in the README). Initial implementation by @wanderanimrod and @dev-jin.
+
 ## [v0.11.0] - 2023-09-22
 
 ### Added 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
   The log level (one of `debug`, `info`, `warn`, `error`, `silent`).\
   Default: `info`.
 
+- `github_hostname`:\
+  GitHub hostname. This allows to post commit statuses to repositories hosted by GitHub Enterprise (GHE) instances. For example: github.mycompany.org will be expanded by cogito to https://github.mycompany.org/api/v3.\
+  Default: `github.com`
+
 - `log_url`. **DEPRECATED, no-op, will be removed**\
   A Google Hangout Chat webhook. Useful to obtain logging for the `check` step for Concourse < v7.x
 

--- a/cmd/cogito/main.go
+++ b/cmd/cogito/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/Pix4D/cogito/cogito"
-	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/sets"
 )
 
@@ -50,20 +49,13 @@ func mainErr(in io.Reader, out io.Writer, logOut io.Writer, args []string) error
 	})
 	log.Info(cogito.BuildInfo())
 
-	ghAPI := os.Getenv("COGITO_GITHUB_API")
-	if ghAPI != "" {
-		log.Info("endpoint override", "COGITO_GITHUB_API", ghAPI)
-	} else {
-		ghAPI = github.API
-	}
-
 	switch cmd {
 	case "check":
 		return cogito.Check(log, input, out, args[1:])
 	case "in":
 		return cogito.Get(log, input, out, args[1:])
 	case "out":
-		putter := cogito.NewPutter(ghAPI, log)
+		putter := cogito.NewPutter(log)
 		return cogito.Put(log, input, out, args[1:], putter)
 	default:
 		return fmt.Errorf("cli wiring error; please report")

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -80,7 +80,7 @@ func TestRunPutSuccess(t *testing.T) {
 	var out bytes.Buffer
 	var logOut bytes.Buffer
 	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
-		testhelp.HttpsRemote("the-owner", "the-repo"), "dummySHA", wantGitRef)
+		testhelp.HttpsRemote("github.com", "the-owner", "the-repo"), "dummySHA", wantGitRef)
 	t.Setenv("COGITO_GITHUB_API", gitHubSpy.URL)
 
 	err := mainErr(in, &out, &logOut, []string{"out", inputDir})
@@ -115,7 +115,7 @@ func TestRunPutSuccessIntegration(t *testing.T) {
 	var out bytes.Buffer
 	var logOut bytes.Buffer
 	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
-		testhelp.HttpsRemote(gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
+		testhelp.HttpsRemote("github.com", gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
 		"ref: refs/heads/a-branch-FIXME")
 	t.Setenv("BUILD_JOB_NAME", "TestRunPutSuccessIntegration")
 	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.invalid")

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -81,7 +81,6 @@ func TestRunPutSuccess(t *testing.T) {
 	var logOut bytes.Buffer
 	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
 		testhelp.HttpsRemote("github.com", "the-owner", "the-repo"), "dummySHA", wantGitRef)
-	t.Setenv("COGITO_GITHUB_API", gitHubSpy.URL)
 
 	err := mainErr(in, &out, &logOut, []string{"out", inputDir})
 

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -64,9 +64,7 @@ func TestRunPutSuccess(t *testing.T) {
 	var ghUrl *url.URL
 	gitHubSpy := testhelp.SpyHttpServer(&ghReq, nil, &ghUrl, http.StatusCreated)
 	gitHubSpyURL, err := url.Parse(gitHubSpy.URL)
-	if err != nil {
-		t.Fatalf("error parsing SpyHttpServer URL: %s", err)
-	}
+	assert.NilError(t, err, "error parsing SpyHttpServer URL: %s", err)
 	var chatMsg googlechat.BasicMessage
 	chatReply := googlechat.MessageReply{}
 	var gchatUrl *url.URL

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -122,8 +122,8 @@ func gChatBuildSummaryText(gitRef string, state BuildState, src Source, env Envi
 	fmt.Fprintf(&bld, "*state* %s\n", decorateState(state))
 	// An empty gitRef means that cogito has been configured as chat only.
 	if gitRef != "" {
-		commitUrl := fmt.Sprintf("https://github.com/%s/%s/commit/%s",
-			src.Owner, src.Repo, gitRef)
+		commitUrl := fmt.Sprintf("https://%s/%s/%s/commit/%s",
+			src.GhHostname, src.Owner, src.Repo, gitRef)
 		commit := fmt.Sprintf("<%s|%.10s> (repo: %s/%s)",
 			commitUrl, gitRef, src.Owner, src.Repo)
 		fmt.Fprintf(&bld, "*commit* %s\n", commit)

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -1,9 +1,7 @@
 package cogito
 
 import (
-	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -43,7 +41,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 	context := ghMakeContext(sink.Request)
 
 	target := &github.Target{
-		Server: apiEndpoint(sink.Request.Source.GhHostname),
+		Server: github.ApiRoot(sink.Request.Source.GhHostname),
 		Retry: retry.Retry{
 			FirstDelay:   retryFirstDelay,
 			BackoffLimit: retryBackoffLimit,
@@ -90,12 +88,4 @@ func ghMakeContext(request PutRequest) string {
 		context += request.Env.BuildJobName
 	}
 	return context
-}
-
-func apiEndpoint(h string) string {
-	hostname := strings.ToLower(h)
-	if strings.Contains(hostname, "127.0.0.1") {
-		return fmt.Sprintf("http://%s", hostname)
-	}
-	return github.API
 }

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -1,7 +1,9 @@
 package cogito
 
 import (
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -41,6 +43,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 	context := ghMakeContext(sink.Request)
 
 	target := &github.Target{
+		Server: apiEndpoint(sink.Request.Source.GhHostname),
 		Retry: retry.Retry{
 			FirstDelay:   retryFirstDelay,
 			BackoffLimit: retryBackoffLimit,
@@ -87,4 +90,12 @@ func ghMakeContext(request PutRequest) string {
 		context += request.Env.BuildJobName
 	}
 	return context
+}
+
+func apiEndpoint(h string) string {
+	hostname := strings.ToLower(h)
+	if strings.Contains(hostname, "127.0.0.1") {
+		return fmt.Sprintf("http://%s", hostname)
+	}
+	return github.API
 }

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -27,7 +27,6 @@ const (
 // GitHubCommitStatusSink is an implementation of [Sinker] for the Cogito resource.
 type GitHubCommitStatusSink struct {
 	Log     hclog.Logger
-	GhAPI   string
 	GitRef  string
 	Request PutRequest
 }
@@ -42,7 +41,6 @@ func (sink GitHubCommitStatusSink) Send() error {
 	context := ghMakeContext(sink.Request)
 
 	target := &github.Target{
-		Server: sink.GhAPI,
 		Retry: retry.Retry{
 			FirstDelay:   retryFirstDelay,
 			BackoffLimit: retryBackoffLimit,

--- a/cogito/ghcommitsink_test.go
+++ b/cogito/ghcommitsink_test.go
@@ -25,7 +25,6 @@ func TestSinkGitHubCommitStatusSendSuccess(t *testing.T) {
 	ts := testhelp.SpyHttpServer(&ghReq, nil, &URL, http.StatusCreated)
 	sink := cogito.GitHubCommitStatusSink{
 		Log:    hclog.NewNullLogger(),
-		GhAPI:  ts.URL,
 		GitRef: wantGitRef,
 		Request: cogito.PutRequest{
 			Params: cogito.PutParams{State: wantState},
@@ -50,7 +49,6 @@ func TestSinkGitHubCommitStatusSendFailure(t *testing.T) {
 	defer ts.Close()
 	sink := cogito.GitHubCommitStatusSink{
 		Log:    hclog.NewNullLogger(),
-		GhAPI:  ts.URL,
 		GitRef: "deadbeefdeadbeef",
 		Request: cogito.PutRequest{
 			Params: cogito.PutParams{State: cogito.StatePending},

--- a/cogito/ghcommitsink_test.go
+++ b/cogito/ghcommitsink_test.go
@@ -24,9 +24,7 @@ func TestSinkGitHubCommitStatusSendSuccess(t *testing.T) {
 	var URL *url.URL
 	ts := testhelp.SpyHttpServer(&ghReq, nil, &URL, http.StatusCreated)
 	gitHubSpyURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("error parsing SpyHttpServer URL: %s", err)
-	}
+	assert.NilError(t, err, "error parsing SpyHttpServer URL: %s", err)
 	sink := cogito.GitHubCommitStatusSink{
 		Log:    hclog.NewNullLogger(),
 		GitRef: wantGitRef,
@@ -52,9 +50,7 @@ func TestSinkGitHubCommitStatusSendFailure(t *testing.T) {
 			w.WriteHeader(http.StatusTeapot)
 		}))
 	gitHubSpyURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("error parsing SpyHttpServer URL: %s", err)
-	}
+	assert.NilError(t, err, "error parsing SpyHttpServer URL: %s", err)
 	defer ts.Close()
 	sink := cogito.GitHubCommitStatusSink{
 		Log:    hclog.NewNullLogger(),

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -263,11 +263,7 @@ func (src *Source) Validate() error {
 	//
 	// Validate optional fields.
 	//
-	if src.GhHostname != "" {
-		if !hostnameRegexp.MatchString(src.GhHostname) {
-			return fmt.Errorf("source: invalid github_api_hostname: %s. Don't configure the schema or the path", src.GhHostname)
-		}
-	}
+	// In this case, nothing to validate.
 
 	//
 	// Apply defaults.
@@ -281,6 +277,11 @@ func (src *Source) Validate() error {
 	if src.GhHostname == "" {
 		src.GhHostname = github.GhDefaultHostname
 	}
+	// Validate src.GhHostname
+	if !hostnameRegexp.MatchString(src.GhHostname) {
+		return fmt.Errorf("source: invalid github_api_hostname: %s. Don't configure the schema or the path", src.GhHostname)
+	}
+
 	return nil
 }
 

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -8,11 +8,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/sets"
 )
+
+var hostnameRegexp = regexp.MustCompile(`^(?P<host>[a-zA-Z0-9.-]+)(?::(?P<port>\d+))?$`)
 
 // DummyVersion is the version always returned by the Cogito resource.
 // DO NOT REASSIGN!
@@ -260,7 +263,11 @@ func (src *Source) Validate() error {
 	//
 	// Validate optional fields.
 	//
-	// In this case, nothing to validate.
+	if src.GhHostname != "" {
+		if !hostnameRegexp.MatchString(src.GhHostname) {
+			return fmt.Errorf("source: invalid github_api_hostname: %s. Don't configure the schema or the path", src.GhHostname)
+		}
+	}
 
 	//
 	// Apply defaults.

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/sets"
 )
 
@@ -164,6 +165,7 @@ type Source struct {
 	//
 	// Optional
 	//
+	GhHostname         string       `json:"github_hostname"`
 	GChatWebHook       string       `json:"gchat_webhook"` // SENSITIVE
 	LogLevel           string       `json:"log_level"`
 	LogUrl             string       `json:"log_url"` // DEPRECATED
@@ -179,6 +181,7 @@ func (src Source) String() string {
 
 	fmt.Fprintf(&bld, "owner:                 %s\n", src.Owner)
 	fmt.Fprintf(&bld, "repo:                  %s\n", src.Repo)
+	fmt.Fprintf(&bld, "github_hostname:       %s\n", src.GhHostname)
 	fmt.Fprintf(&bld, "access_token:          %s\n", redact(src.AccessToken))
 	fmt.Fprintf(&bld, "gchat_webhook:         %s\n", redact(src.GChatWebHook))
 	fmt.Fprintf(&bld, "log_level:             %s\n", src.LogLevel)
@@ -268,7 +271,9 @@ func (src *Source) Validate() error {
 	if len(src.ChatNotifyOnStates) == 0 {
 		src.ChatNotifyOnStates = defaultNotifyStates
 	}
-
+	if src.GhHostname == "" {
+		src.GhHostname = github.GhDefaultHostname
+	}
 	return nil
 }
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -175,6 +175,7 @@ func TestSourcePrintLogRedaction(t *testing.T) {
 	source := cogito.Source{
 		Owner:              "the-owner",
 		Repo:               "the-repo",
+		GhHostname:         "github.com",
 		AccessToken:        "sensitive-the-access-token",
 		GChatWebHook:       "sensitive-gchat-webhook",
 		LogLevel:           "debug",
@@ -186,6 +187,7 @@ func TestSourcePrintLogRedaction(t *testing.T) {
 	t.Run("fmt.Print redacts fields", func(t *testing.T) {
 		want := `owner:                 the-owner
 repo:                  the-repo
+github_hostname:       github.com
 access_token:          ***REDACTED***
 gchat_webhook:         ***REDACTED***
 log_level:             debug
@@ -205,6 +207,7 @@ sinks: []`
 		}
 		want := `owner:                 the-owner
 repo:                  
+github_hostname:       
 access_token:          
 gchat_webhook:         
 log_level:             

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -46,6 +46,22 @@ func TestSourceValidationSuccess(t *testing.T) {
 				return source
 			},
 		},
+		{
+			name: "git source: github_hostname: httptest server hostname",
+			mkSource: func() cogito.Source {
+				source := baseGithubSource
+				source.GhHostname = "127.0.0.1:1234"
+				return source
+			},
+		},
+		{
+			name: "git source: github_hostname: github.foo.com",
+			mkSource: func() cogito.Source {
+				source := baseGithubSource
+				source.GhHostname = "github.foo.com"
+				return source
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -101,6 +117,16 @@ func TestSourceValidationFailure(t *testing.T) {
 				AccessToken:  "the-token",
 			},
 			wantErr: "source: invalid sink(s): [closed coffee shop]",
+		},
+		{
+			name: "invalid github_hostname: configured with schema, the path or both",
+			source: cogito.Source{
+				GhHostname:  "https://github.foo.com/api/v3/",
+				Owner:       "the-owner",
+				Repo:        "the-repo",
+				AccessToken: "the-token",
+			},
+			wantErr: "source: invalid github_api_hostname: https://github.foo.com/api/v3/. Don't configure the schema or the path",
 		},
 	}
 

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -123,7 +123,7 @@ func TestPutFailure(t *testing.T) {
 
 func TestPutterLoadConfigurationSuccess(t *testing.T) {
 	in := testhelp.ToJSON(t, basePutRequest)
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, []string{"dummy-dir"})
 
@@ -142,7 +142,7 @@ func TestPutterLoadConfigurationSinksOverrideSuccess(t *testing.T) {
 	},
 	  "params": {"sinks": ["gchat"]}
 	}`)
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 	inputDir := []string{""}
 	err := putter.LoadConfiguration(in, inputDir)
 	assert.NilError(t, err)
@@ -163,7 +163,7 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 
 	test := func(t *testing.T, tc testCase) {
 		in := testhelp.ToJSON(t, tc.putInput)
-		putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+		putter := cogito.NewPutter(hclog.NewNullLogger())
 
 		err := putter.LoadConfiguration(in, tc.args)
 
@@ -204,7 +204,7 @@ func TestPutterLoadConfigurationInvalidParamsFailure(t *testing.T) {
   "params": {"pizza": "margherita"}
 }`)
 	wantErr := `put: parsing request: json: unknown field "pizza"`
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)
 
@@ -218,7 +218,7 @@ func TestPutterLoadConfigurationMissingGchatwebHook(t *testing.T) {
   "params": {}
 }`)
 	wantErr := `put: source: missing keys: gchat_webhook`
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)
 
@@ -232,7 +232,7 @@ func TestPutterLoadConfigurationUnknownSink(t *testing.T) {
   "params": {}
 }`)
 	wantErr := `put: source: invalid sink(s): [pizza]`
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)
 
@@ -246,7 +246,7 @@ func TestPutterLoadConfigurationUnknownSinkPutParams(t *testing.T) {
   "params": {"sinks": ["pizza"]}
 }`)
 	wantErr := `put: arguments: unsupported sink(s): [pizza]`
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.LoadConfiguration(in, nil)
 
@@ -262,7 +262,7 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 	}
 
 	test := func(t *testing.T, tc testCase) {
-		putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+		putter := cogito.NewPutter(hclog.NewNullLogger())
 		tmpDir := testhelp.MakeGitRepoFromTestdata(t, tc.inputDir,
 			"https://github.com/dummy-owner/dummy-repo", "dummySHA", "banana")
 		putter.InputDir = filepath.Join(tmpDir, filepath.Base(tc.inputDir))
@@ -317,7 +317,7 @@ func TestPutterProcessInputDirFailure(t *testing.T) {
 	test := func(t *testing.T, tc testCase) {
 		tmpDir := testhelp.MakeGitRepoFromTestdata(t, tc.inputDir,
 			"https://github.com/dummy-owner/dummy-repo", "dummySHA", "banana mango")
-		putter := cogito.NewPutter("dummy-api", hclog.NewNullLogger())
+		putter := cogito.NewPutter(hclog.NewNullLogger())
 		putter.Request = cogito.PutRequest{
 			Source: cogito.Source{Owner: "dummy-owner", Repo: "dummy-repo"},
 			Params: tc.params,
@@ -394,7 +394,7 @@ func TestPutterProcessInputDirNonExisting(t *testing.T) {
 }
 
 func TestPutterSinks(t *testing.T) {
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	sinks := putter.Sinks()
 	assert.Assert(t, len(sinks) == 2)
@@ -406,7 +406,7 @@ func TestPutterSinks(t *testing.T) {
 }
 
 func TestPutterCustomSinks(t *testing.T) {
-	putter := cogito.NewPutter("dummy-api", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 	putter.Request = cogito.PutRequest{
 		Params: cogito.PutParams{Sinks: []string{"gchat"}},
 	}
@@ -417,7 +417,7 @@ func TestPutterCustomSinks(t *testing.T) {
 }
 
 func TestPutterOutputSuccess(t *testing.T) {
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.Output(io.Discard)
 
@@ -425,7 +425,7 @@ func TestPutterOutputSuccess(t *testing.T) {
 }
 
 func TestPutterOutputFailure(t *testing.T) {
-	putter := cogito.NewPutter("dummy-API", hclog.NewNullLogger())
+	putter := cogito.NewPutter(hclog.NewNullLogger())
 
 	err := putter.Output(&testhelp.FailingWriter{})
 

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/Pix4D/cogito/cogito"
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/testhelp"
 )
 
@@ -267,7 +268,7 @@ func TestPutterProcessInputDirSuccess(t *testing.T) {
 			"https://github.com/dummy-owner/dummy-repo", "dummySHA", "banana")
 		putter.InputDir = filepath.Join(tmpDir, filepath.Base(tc.inputDir))
 		putter.Request = cogito.PutRequest{
-			Source: cogito.Source{Owner: "dummy-owner", Repo: "dummy-repo", Sinks: tc.sink},
+			Source: cogito.Source{GhHostname: github.GhDefaultHostname, Owner: "dummy-owner", Repo: "dummy-repo", Sinks: tc.sink},
 			Params: tc.params,
 		}
 
@@ -319,7 +320,7 @@ func TestPutterProcessInputDirFailure(t *testing.T) {
 			"https://github.com/dummy-owner/dummy-repo", "dummySHA", "banana mango")
 		putter := cogito.NewPutter(hclog.NewNullLogger())
 		putter.Request = cogito.PutRequest{
-			Source: cogito.Source{Owner: "dummy-owner", Repo: "dummy-repo"},
+			Source: cogito.Source{GhHostname: github.GhDefaultHostname, Owner: "dummy-owner", Repo: "dummy-repo"},
 			Params: tc.params,
 		}
 		putter.InputDir = filepath.Join(tmpDir, filepath.Base(tc.inputDir))

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -131,7 +131,7 @@ func (putter *ProdPutter) ProcessInputDir() error {
 	case 1:
 		repoDir := filepath.Join(putter.InputDir, inputDirs.OrderedList()[0])
 		putter.log.Debug("", "inputDirs", inputDirs, "repoDir", repoDir, "msgDir", msgDir)
-		if err := checkGitRepoDir(repoDir, source.Owner, source.Repo); err != nil {
+		if err := checkGitRepoDir(repoDir, source.GhHostname, source.Owner, source.Repo); err != nil {
 			return err
 		}
 		putter.gitRef, err = getGitCommit(repoDir)
@@ -237,7 +237,7 @@ func collectInputDirs(dir string) ([]string, error) {
 // - The repo configuration contains a "remote origin" section.
 // - The remote origin url can be parsed following the GitHub conventions.
 // - The result of the parse matches OWNER and REPO.
-func checkGitRepoDir(dir, owner, repo string) error {
+func checkGitRepoDir(dir, hostname, owner, repo string) error {
 	cfg, err := mini.LoadConfiguration(filepath.Join(dir, ".git/config"))
 	if err != nil {
 		return fmt.Errorf("parsing .git/config: %w", err)
@@ -259,7 +259,7 @@ func checkGitRepoDir(dir, owner, repo string) error {
 	if err != nil {
 		return fmt.Errorf(".git/config: remote: %w", err)
 	}
-	left := []string{"github.com", owner, repo}
+	left := []string{hostname, owner, repo}
 	right := []string{gu.URL.Host, gu.Owner, gu.Repo}
 	for i, l := range left {
 		r := right[i]
@@ -272,10 +272,11 @@ Git repository configuration (received as 'inputs:' in this PUT step):
     repo: %s
 
 Cogito SOURCE configuration:
+    hostname: %s
     owner: %s
     repo: %s`,
 				gitUrl, gu.Owner, gu.Repo,
-				owner, repo)
+				hostname, owner, repo)
 		}
 	}
 	return nil

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -23,16 +23,14 @@ type ProdPutter struct {
 	Request  PutRequest
 	InputDir string
 	// Cogito specific fields.
-	ghAPI  string
 	log    hclog.Logger
 	gitRef string
 }
 
 // NewPutter returns a Cogito ProdPutter.
-func NewPutter(ghAPI string, log hclog.Logger) *ProdPutter {
+func NewPutter(log hclog.Logger) *ProdPutter {
 	return &ProdPutter{
-		ghAPI: ghAPI,
-		log:   log,
+		log: log,
 	}
 }
 
@@ -155,7 +153,6 @@ func (putter *ProdPutter) Sinks() []Sinker {
 	supportedSinkers := map[string]Sinker{
 		"github": GitHubCommitStatusSink{
 			Log:     putter.log.Named("ghCommitStatus"),
-			GhAPI:   putter.ghAPI,
 			GitRef:  putter.gitRef,
 			Request: putter.Request,
 		},

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -270,13 +270,13 @@ func checkGitRepoDir(dir, owner, repo string) error {
 			return fmt.Errorf(`the received git repository is incompatible with the Cogito configuration.
 
 Git repository configuration (received as 'inputs:' in this PUT step):
-      url: %s
+    url: %s
     owner: %s
-     repo: %s
+    repo: %s
 
 Cogito SOURCE configuration:
     owner: %s
-     repo: %s`,
+    repo: %s`,
 				gitUrl, gu.Owner, gu.Repo,
 				owner, repo)
 		}

--- a/cogito/putter_private_test.go
+++ b/cogito/putter_private_test.go
@@ -82,17 +82,17 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 		{
 			name:    "repo with good SSH remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.SshRemote(wantOwner, wantRepo),
+			repoURL: testhelp.SshRemote("github.com", wantOwner, wantRepo),
 		},
 		{
 			name:    "repo with good HTTPS remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpsRemote(wantOwner, wantRepo),
+			repoURL: testhelp.HttpsRemote("github.com", wantOwner, wantRepo),
 		},
 		{
 			name:    "repo with good HTTP remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpRemote(wantOwner, wantRepo),
+			repoURL: testhelp.HttpRemote("github.com", wantOwner, wantRepo),
 		},
 		{
 			name:    "PR resource but with basic auth in URL (see PR #46)",
@@ -143,32 +143,32 @@ func TestCheckGitRepoDirFailure(t *testing.T) {
 		{
 			name:    "repo with unrelated HTTPS remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpsRemote("owner-a", "repo-a"),
+			repoURL: testhelp.HttpsRemote("github.com", "owner-a", "repo-a"),
 			wantErrWild: `the received git repository is incompatible with the Cogito configuration.
 
 Git repository configuration (received as 'inputs:' in this PUT step):
-      url: https://github.com/owner-a/repo-a.git
+    url: https://github.com/owner-a/repo-a.git
     owner: owner-a
-     repo: repo-a
+    repo: repo-a
 
 Cogito SOURCE configuration:
     owner: smiling
-     repo: butterfly`,
+    repo: butterfly`,
 		},
 		{
 			name:    "repo with unrelated SSH remote or wrong source config",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.SshRemote("owner-a", "repo-a"),
+			repoURL: testhelp.SshRemote("github.com", "owner-a", "repo-a"),
 			wantErrWild: `the received git repository is incompatible with the Cogito configuration.
 
 Git repository configuration (received as 'inputs:' in this PUT step):
-      url: git@github.com:owner-a/repo-a.git
+    url: git@github.com:owner-a/repo-a.git
     owner: owner-a
-     repo: repo-a
+    repo: repo-a
 
 Cogito SOURCE configuration:
     owner: smiling
-     repo: butterfly`,
+    repo: butterfly`,
 		},
 		{
 			name:        "invalid git pseudo URL in .git/config",

--- a/cogito/putter_private_test.go
+++ b/cogito/putter_private_test.go
@@ -2,6 +2,7 @@ package cogito
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -65,6 +66,7 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 		repoURL string
 	}
 
+	const wantHostname = "github.com"
 	const wantOwner = "smiling"
 	const wantRepo = "butterfly"
 
@@ -73,7 +75,7 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 			"dummySHA", "dummyHead")
 
 		err := checkGitRepoDir(filepath.Join(inputDir, filepath.Base(tc.dir)),
-			wantOwner, wantRepo)
+			wantHostname, wantOwner, wantRepo)
 
 		assert.NilError(t, err)
 	}
@@ -82,22 +84,22 @@ func TestCheckGitRepoDirSuccess(t *testing.T) {
 		{
 			name:    "repo with good SSH remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.SshRemote("github.com", wantOwner, wantRepo),
+			repoURL: testhelp.SshRemote(wantHostname, wantOwner, wantRepo),
 		},
 		{
 			name:    "repo with good HTTPS remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpsRemote("github.com", wantOwner, wantRepo),
+			repoURL: testhelp.HttpsRemote(wantHostname, wantOwner, wantRepo),
 		},
 		{
 			name:    "repo with good HTTP remote",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: testhelp.HttpRemote("github.com", wantOwner, wantRepo),
+			repoURL: testhelp.HttpRemote(wantHostname, wantOwner, wantRepo),
 		},
 		{
 			name:    "PR resource but with basic auth in URL (see PR #46)",
 			dir:     "testdata/one-repo/a-repo",
-			repoURL: "https://x-oauth-basic:ghp_XXX@github.com/smiling/butterfly.git",
+			repoURL: fmt.Sprintf("https://x-oauth-basic:ghp_XXX@%s/%s/%s.git", wantHostname, wantOwner, wantRepo),
 		},
 	}
 
@@ -114,6 +116,7 @@ func TestCheckGitRepoDirFailure(t *testing.T) {
 		wantErrWild string // wildcard matching
 	}
 
+	const wantHostname = "github.com"
 	const wantOwner = "smiling"
 	const wantRepo = "butterfly"
 
@@ -122,7 +125,7 @@ func TestCheckGitRepoDirFailure(t *testing.T) {
 			"dummySHA", "dummyHead")
 
 		err := checkGitRepoDir(filepath.Join(inDir, filepath.Base(tc.dir)),
-			wantOwner, wantRepo)
+			wantHostname, wantOwner, wantRepo)
 
 		assert.ErrorContains(t, err, tc.wantErrWild)
 	}
@@ -152,6 +155,7 @@ Git repository configuration (received as 'inputs:' in this PUT step):
     repo: repo-a
 
 Cogito SOURCE configuration:
+    hostname: github.com
     owner: smiling
     repo: butterfly`,
 		},
@@ -167,6 +171,7 @@ Git repository configuration (received as 'inputs:' in this PUT step):
     repo: repo-a
 
 Cogito SOURCE configuration:
+    hostname: github.com
     owner: smiling
     repo: butterfly`,
 		},

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -31,10 +31,10 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("%s\n%s", e.What, e.Details)
 }
 
-// Default GitHub hostname
+// GhDefaultHostname is the default GitHub hostname (used for git but not for the API)
 const GhDefaultHostname = "github.com"
 
-// API is the GitHub API endpoint.
+// API is the default GitHub API hostname.
 const API = "https://api.github.com"
 
 type Target struct {

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -31,12 +31,14 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("%s\n%s", e.What, e.Details)
 }
 
+// Default GitHub hostname
+const GhDefaultHostname = "github.com"
+
 // API is the GitHub API endpoint.
 const API = "https://api.github.com"
 
 type Target struct {
 	// Server is the GitHub API server.
-	// Currently, hardcoded to https://api.github.com
 	Server string
 	// Retry controls the retry logic.
 	Retry retry.Retry

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -196,13 +196,17 @@ func (cs CommitStatus) explainError(err error, state, sha, url string) error {
 
 // ApiRoot constructs the root part of the GitHub API URL for a given hostname.
 // Example:
-// if hostname is: github.com it returns https://api.github.com
-// if hostname is overrriden in tests by localhost HTTP testserver it returns http://127.0.0.1:PORT
+// if hostname is github.com it returns https://api.github.com
+// if hostname looks like a httptest server, it returns http://127.0.0.1:PORT
+// otherwise, hostname is assumed to be of a Github Enterprise instance.
+// For example, github.mycompany.org returns https://github.mycompany.org/api/v3
 func ApiRoot(h string) string {
 	hostname := strings.ToLower(h)
+	if hostname == GhDefaultHostname {
+		return API
+	}
 	if localhostRegexp.MatchString(hostname) {
 		return fmt.Sprintf("http://%s", hostname)
 	}
-
-	return API
+	return fmt.Sprintf("https://%s/api/v3", hostname)
 }

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -190,3 +190,11 @@ func (cs CommitStatus) explainError(err error, state, sha, url string) error {
 		Details: fmt.Sprintf("Action: %s %s", http.MethodPost, url),
 	}
 }
+
+func ApiRoot(h string) string {
+	hostname := strings.ToLower(h)
+	if strings.Contains(hostname, "127.0.0.1") {
+		return fmt.Sprintf("http://%s", hostname)
+	}
+	return API
+}

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,8 +35,10 @@ func (e *StatusError) Error() string {
 // GhDefaultHostname is the default GitHub hostname (used for git but not for the API)
 const GhDefaultHostname = "github.com"
 
-// API is the default GitHub API hostname.
+// API is the default GitHub API root URL.
 const API = "https://api.github.com"
+
+var localhostRegexp = regexp.MustCompile(`^127.0.0.1:[0-9]+$`)
 
 type Target struct {
 	// Server is the GitHub API server.
@@ -194,11 +197,12 @@ func (cs CommitStatus) explainError(err error, state, sha, url string) error {
 // ApiRoot constructs the root part of the GitHub API URL for a given hostname.
 // Example:
 // if hostname is: github.com it returns https://api.github.com
-// if hostname is overrriden in tests by localhost HTTP testserver it returns http://127.0.0.1
+// if hostname is overrriden in tests by localhost HTTP testserver it returns http://127.0.0.1:PORT
 func ApiRoot(h string) string {
 	hostname := strings.ToLower(h)
-	if strings.Contains(hostname, "127.0.0.1") {
+	if localhostRegexp.MatchString(hostname) {
 		return fmt.Sprintf("http://%s", hostname)
 	}
+
 	return API
 }

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -35,9 +35,6 @@ func (e *StatusError) Error() string {
 // GhDefaultHostname is the default GitHub hostname (used for git but not for the API)
 const GhDefaultHostname = "github.com"
 
-// API is the default GitHub API root URL.
-const API = "https://api.github.com"
-
 var localhostRegexp = regexp.MustCompile(`^127.0.0.1:[0-9]+$`)
 
 type Target struct {
@@ -203,7 +200,7 @@ func (cs CommitStatus) explainError(err error, state, sha, url string) error {
 func ApiRoot(h string) string {
 	hostname := strings.ToLower(h)
 	if hostname == GhDefaultHostname {
-		return API
+		return "https://api.github.com"
 	}
 	if localhostRegexp.MatchString(hostname) {
 		return fmt.Sprintf("http://%s", hostname)

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -191,6 +191,10 @@ func (cs CommitStatus) explainError(err error, state, sha, url string) error {
 	}
 }
 
+// ApiRoot constructs the root part of the GitHub API URL for a given hostname.
+// Example:
+// if hostname is: github.com it returns https://api.github.com
+// if hostname is overrriden in tests by localhost HTTP testserver it returns http://127.0.0.1
 func ApiRoot(h string) string {
 	hostname := strings.ToLower(h)
 	if strings.Contains(hostname, "127.0.0.1") {

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -481,6 +481,11 @@ func TestApiRoot(t *testing.T) {
 			hostname: github.GhDefaultHostname,
 			wantAPI:  github.API,
 		},
+		{
+			name:     "Github Enterprise hostname",
+			hostname: "github.mycompany.org",
+			wantAPI:  "https://github.mycompany.org/api/v3",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -337,7 +337,7 @@ func TestGitHubStatusSuccessIntegration(t *testing.T) {
 		log = hclog.Default()
 	}
 	target := &github.Target{
-		Server: github.API,
+		Server: github.ApiRoot(github.GhDefaultHostname),
 		Retry: retry.Retry{
 			FirstDelay:   retryFirstDelay,
 			BackoffLimit: retryBackoffLimit,
@@ -390,7 +390,7 @@ func TestGitHubStatusFailureIntegration(t *testing.T) {
 		}
 
 		target := &github.Target{
-			Server: github.API,
+			Server: github.ApiRoot(github.GhDefaultHostname),
 			Retry: retry.Retry{
 				FirstDelay:   retryFirstDelay,
 				BackoffLimit: retryBackoffLimit,
@@ -479,7 +479,7 @@ func TestApiRoot(t *testing.T) {
 		{
 			name:     "default GitHub hostname",
 			hostname: github.GhDefaultHostname,
-			wantAPI:  github.API,
+			wantAPI:  "https://api.github.com",
 		},
 		{
 			name:     "Github Enterprise hostname",

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -457,3 +457,33 @@ type SleepSpy struct {
 func (spy *SleepSpy) Sleep(d time.Duration) {
 	spy.sleeps = append(spy.sleeps, d)
 }
+
+func TestApiRoot(t *testing.T) {
+	type testCase struct {
+		name     string
+		hostname string
+		wantAPI  string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		got := github.ApiRoot(tc.hostname)
+		assert.Equal(t, got, tc.wantAPI)
+	}
+
+	testCases := []testCase{
+		{
+			name:     "hostname is localhost from http testserver",
+			hostname: "127.0.0.1:5678",
+			wantAPI:  "http://127.0.0.1:5678",
+		},
+		{
+			name:     "default GitHub hostname",
+			hostname: github.GhDefaultHostname,
+			wantAPI:  github.API,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { run(t, tc) })
+	}
+}

--- a/testhelp/testhelper.go
+++ b/testhelp/testhelper.go
@@ -247,18 +247,18 @@ func MakeGitRepoFromTestdata(
 }
 
 // SshRemote returns a GitHub SSH URL
-func SshRemote(domain, owner, repo string) string {
-	return fmt.Sprintf("git@%s:%s/%s.git", domain, owner, repo)
+func SshRemote(hostname, owner, repo string) string {
+	return fmt.Sprintf("git@%s:%s/%s.git", hostname, owner, repo)
 }
 
 // HttpsRemote returns a GitHub HTTPS URL
-func HttpsRemote(domain, owner, repo string) string {
-	return fmt.Sprintf("https://%s/%s/%s.git", domain, owner, repo)
+func HttpsRemote(hostname, owner, repo string) string {
+	return fmt.Sprintf("https://%s/%s/%s.git", hostname, owner, repo)
 }
 
 // HttpRemote returns a GitHub HTTP URL
-func HttpRemote(domain, owner, repo string) string {
-	return fmt.Sprintf("http://%s/%s/%s.git", domain, owner, repo)
+func HttpRemote(hostname, owner, repo string) string {
+	return fmt.Sprintf("http://%s/%s/%s.git", hostname, owner, repo)
 }
 
 // ToJSON returns the JSON encoding of thing.

--- a/testhelp/testhelper.go
+++ b/testhelp/testhelper.go
@@ -247,18 +247,18 @@ func MakeGitRepoFromTestdata(
 }
 
 // SshRemote returns a GitHub SSH URL
-func SshRemote(owner, repo string) string {
-	return fmt.Sprintf("git@github.com:%s/%s.git", owner, repo)
+func SshRemote(domain, owner, repo string) string {
+	return fmt.Sprintf("git@%s:%s/%s.git", domain, owner, repo)
 }
 
 // HttpsRemote returns a GitHub HTTPS URL
-func HttpsRemote(owner, repo string) string {
-	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+func HttpsRemote(domain, owner, repo string) string {
+	return fmt.Sprintf("https://%s/%s/%s.git", domain, owner, repo)
 }
 
 // HttpRemote returns a GitHub HTTP URL
-func HttpRemote(owner, repo string) string {
-	return fmt.Sprintf("http://github.com/%s/%s.git", owner, repo)
+func HttpRemote(domain, owner, repo string) string {
+	return fmt.Sprintf("http://%s/%s/%s.git", domain, owner, repo)
 }
 
 // ToJSON returns the JSON encoding of thing.


### PR DESCRIPTION
- adds a possibility to configure `source.github_hostname` to allow for overriding of the GitHub hostname only from the tests. This helps us avoid a very ugly implementation with: `os.Getenv("COGITO_GITHUB_API")`. Default value is of course: `github.com`
- this step forces us to remove the hardcoded `github.com` from basically everywhere
- even the implicit dependency in Gchat putter that I reported is fixed (https://github.com/Pix4D/cogito/commit/362de679d8ba054f909d972f31b4796268f921bd)

We then later craft the API endpoint using: `func apiEndpoint(h string) string` function.

No tests were added, at least not for now. I think everything is covered by the existing tests. I could add the unit test for `apiEndpoint` function actually.

I will open a draft follow-up PR on top of this one, just to show you how simple will be to allow the GH Enterprise if this PR is merged.

