### PR TITLE
release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.12.0] - Unreleased
+## [v0.12.0] - 2023-11-03
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ With reference to the [GitHub Commit status API], the `POST` parameters (`state`
   Default: `info`.
 
 - `github_hostname`:\
-  GitHub hostname. This allows to post commit statuses to repositories hosted by GitHub Enterprise (GHE) instances. For example: github.mycompany.org will be expanded by cogito to https://github.mycompany.org/api/v3.\
+  GitHub hostname. This allows to post commit statuses to repositories hosted by GitHub Enterprise (GHE) instances. For example: github.mycompany.org will be expanded by cogito to https://github.mycompany.org/api/v3 \
   Default: `github.com`
 
 - `log_url`. **DEPRECATED, no-op, will be removed**\


### PR DESCRIPTION
release PR for v0.12.0

@wanderanimrod and @dev-jin the PRs to add support for the GHE are finally merged to master. Do you mind doing the final tests with the master image `pix4d/cogito:master` before the release 0.12.0 is out?

Note that there are some configuration changes needed compared to the previous attempt.

See: https://github.com/Pix4D/cogito#optional-keys

In current implementation we expect:
`source.github_hostname` to be configured as: `github.mycompany.org` WITHOUT any schema/protocol (`https://`) or API prefix (`/api/v3`).
This will be expanded in the code to: `https://github.mycompany.org/api/v3`.

TODO:
- [ ] put the correct date in the changelog