### PR TITLE
cogito: properly encode url

### DIFF
--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -333,6 +333,12 @@ func concourseBuildURL(env Environment) string {
 	// https://ci.example.com/teams/main/pipelines/cogito/jobs/autocat/builds/3?vars=%7B%22branch%22%3A%22stable%22%7D
 	if env.BuildPipelineInstanceVars != "" {
 		buildURL += fmt.Sprintf("?vars=%s", url.QueryEscape(env.BuildPipelineInstanceVars))
+		// Concourse requires that the space characters
+		// are encoded as %20 instead of +. On the other hand
+		// golangs url.QueryEscape as well as url.Values.Encode()
+		// both encode the space as a + character.
+		// See: https://github.com/golang/go/issues/4013
+		buildURL = strings.ReplaceAll(buildURL, "+", "%20")
 	}
 
 	return buildURL

--- a/cogito/putter_private_test.go
+++ b/cogito/putter_private_test.go
@@ -342,13 +342,13 @@ func TestConcourseBuildURL(t *testing.T) {
 			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42",
 		},
 		{
-			name: "instanced vars 1",
+			name: "single instance variable",
 			env: testhelp.MergeStructs(baseEnv,
 				Environment{BuildPipelineInstanceVars: `{"branch":"stable"}`}),
 			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42?vars=%7B%22branch%22%3A%22stable%22%7D",
 		},
 		{
-			name: "instanced vars 2",
+			name: "multiple instance variables",
 			env: testhelp.MergeStructs(baseEnv,
 				Environment{BuildPipelineInstanceVars: `{"branch":"stable","foo":"bar"}`}),
 			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42?vars=%7B%22branch%22%3A%22stable%22%2C%22foo%22%3A%22bar%22%7D",

--- a/cogito/putter_private_test.go
+++ b/cogito/putter_private_test.go
@@ -348,10 +348,22 @@ func TestConcourseBuildURL(t *testing.T) {
 			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42?vars=%7B%22branch%22%3A%22stable%22%7D",
 		},
 		{
+			name: "single instance variable with spaces",
+			env: testhelp.MergeStructs(baseEnv,
+				Environment{BuildPipelineInstanceVars: `{"branch":"foo bar"}`}),
+			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42?vars=%7B%22branch%22%3A%22foo%20bar%22%7D",
+		},
+		{
 			name: "multiple instance variables",
 			env: testhelp.MergeStructs(baseEnv,
 				Environment{BuildPipelineInstanceVars: `{"branch":"stable","foo":"bar"}`}),
 			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42?vars=%7B%22branch%22%3A%22stable%22%2C%22foo%22%3A%22bar%22%7D",
+		},
+		{
+			name: "multiple instance variables: nested json with spaces",
+			env: testhelp.MergeStructs(baseEnv,
+				Environment{BuildPipelineInstanceVars: `{"branch":"foo bar","version":{"from":1.0,"to":2.0}}`}),
+			want: "https://ci.example.com/teams/devs/pipelines/magritte/jobs/paint/builds/42?vars=%7B%22branch%22%3A%22foo%20bar%22%2C%22version%22%3A%7B%22from%22%3A1.0%2C%22to%22%3A2.0%7D%7D",
 		},
 	}
 


### PR DESCRIPTION
cogito: properly encode url

Actually, the only problem that existed was due the way spaces were encoded. Even the most complex case with nested json worked fine with the existing code. The only thing "missing" was the proper encoding of spaces.

Concourse requires that the space characters are encoded as %20 instead of +. On the other hand golangs url.QueryEscape as well as url.Values.Encode() both encode the space as a + character.
See: https://github.com/golang/go/issues/4013

Fixes: https://github.com/Pix4D/cogito/issues/148