### PR TITLE
github: add support for github apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         env:
           COGITO_TEST_OAUTH_TOKEN: ${{ secrets.COGITO_TEST_OAUTH_TOKEN }}
           COGITO_TEST_GCHAT_HOOK: ${{ secrets.COGITO_TEST_GCHAT_HOOK }}
+          COGITO_TEST_GH_APP_PRIVATE_KEY: |
+            ${{ secrets.COGITO_TEST_GH_APP_PRIVATE_KEY }}
       - run: task docker:build
       - run: task docker:smoke
       - run: task docker:login

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,6 +57,10 @@ tasks:
       COGITO_TEST_REPO_OWNER: '{{default "pix4d" .COGITO_TEST_REPO_OWNER}}'
       COGITO_TEST_GCHAT_HOOK:
         sh: 'echo {{default "$(gopass show cogito/test_gchat_webhook)" .COGITO_TEST_GCHAT_HOOK}}'
+      COGITO_TEST_GH_APP_CLIENT_ID: '{{default "Iv23lir9pyQlqmweDPbz" .COGITO_TEST_GH_APP_CLIENT_ID}}'
+      COGITO_TEST_GH_APP_INSTALLATION_ID: '{{default "64650729" .COGITO_TEST_GH_APP_INSTALLATION_ID}}'
+      COGITO_TEST_GH_APP_PRIVATE_KEY:
+        sh: 'echo "{{default "$(gopass show cogito/test_gh_app_private_key)" .COGITO_TEST_GH_APP_PRIVATE_KEY}}"'
 
   test:unit:
     desc: Run the unit tests.

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -141,7 +141,7 @@ func TestRunPutGhAppSuccessIntegration(t *testing.T) {
 	}
 
 	gitHubCfg := testhelp.GitHubSecretsOrFail(t)
-	ghAppInstallationID, err := strconv.ParseInt(gitHubCfg.GhAppInstallationID, 10, 64)
+	ghAppInstallationID, err := strconv.ParseInt(gitHubCfg.GhAppInstallationID, 10, 32)
 	assert.NilError(t, err)
 
 	stdin := bytes.NewReader(testhelp.ToJSON(t, cogito.PutRequest{
@@ -150,7 +150,7 @@ func TestRunPutGhAppSuccessIntegration(t *testing.T) {
 			Repo:  gitHubCfg.Repo,
 			GitHubApp: github.GitHubApp{
 				ClientId:       gitHubCfg.GhAppClientID,
-				InstallationId: ghAppInstallationID,
+				InstallationId: int(ghAppInstallationID),
 				PrivateKey:     gitHubCfg.GhAppPrivateKey,
 			},
 			LogLevel: "debug",

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -132,6 +133,46 @@ func TestRunPutSuccessIntegration(t *testing.T) {
 		`level=INFO msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
 	assert.Assert(t, cmp.Contains(stderr.String(),
 		`level=INFO msg="state posted successfully to chat" name=cogito.put name=gChat state=error`))
+}
+
+func TestRunPutGhAppSuccessIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test (reason: -short)")
+	}
+
+	gitHubCfg := testhelp.GitHubSecretsOrFail(t)
+	ghAppInstallationID, err := strconv.ParseInt(gitHubCfg.GhAppInstallationID, 10, 64)
+	assert.NilError(t, err)
+
+	stdin := bytes.NewReader(testhelp.ToJSON(t, cogito.PutRequest{
+		Source: cogito.Source{
+			Owner: gitHubCfg.Owner,
+			Repo:  gitHubCfg.Repo,
+			GitHubApp: github.GitHubApp{
+				ClientId:       gitHubCfg.GhAppClientID,
+				InstallationId: ghAppInstallationID,
+				PrivateKey:     gitHubCfg.GhAppPrivateKey,
+			},
+			LogLevel: "debug",
+		},
+		Params: cogito.PutParams{State: cogito.StateError},
+	}))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	inputDir := testhelp.MakeGitRepoFromTestdata(t, "../../cogito/testdata/one-repo/a-repo",
+		testhelp.HttpsRemote(github.GhDefaultHostname, gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
+		"ref: refs/heads/a-branch-FIXME")
+	t.Setenv("BUILD_JOB_NAME", "TestRunPutGhAppSuccessIntegration")
+	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.invalid")
+	t.Setenv("BUILD_PIPELINE_NAME", "the-test-pipeline")
+	t.Setenv("BUILD_TEAM_NAME", "the-test-team")
+	t.Setenv("BUILD_NAME", "42")
+
+	err = mainErr(stdin, &stdout, &stderr, []string{"out", inputDir})
+
+	assert.NilError(t, err, "\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	assert.Assert(t, cmp.Contains(stderr.String(),
+		`level=INFO msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
 }
 
 func TestRunFailure(t *testing.T) {

--- a/cogito/check_test.go
+++ b/cogito/check_test.go
@@ -8,6 +8,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/Pix4D/cogito/cogito"
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/testhelp"
 )
 
@@ -88,10 +89,25 @@ func TestCheckFailure(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:    "validation failure: missing repo keys",
+			name:    "validation failure: missing access token or github_app",
 			source:  cogito.Source{},
 			writer:  io.Discard,
-			wantErr: "check: source: missing keys: owner, repo, access_token",
+			wantErr: "check: source: one of access_token or github_app must be specified",
+		},
+		{
+			name: "validation failure: both access_key and github_app are set",
+			source: cogito.Source{
+				AccessToken: "dummy-token",
+				GitHubApp:   github.GitHubApp{ClientId: "client-id"},
+			},
+			writer:  io.Discard,
+			wantErr: "check: source: cannot specify both github_app and access_token",
+		},
+		{
+			name:    "validation failure: missing repo keys",
+			source:  cogito.Source{AccessToken: "dummy-token"},
+			writer:  io.Discard,
+			wantErr: "check: source: missing keys: owner, repo",
 		},
 		{
 			name: "validation failure: missing gchat keys",

--- a/cogito/get_test.go
+++ b/cogito/get_test.go
@@ -8,6 +8,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/Pix4D/cogito/cogito"
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/testhelp"
 )
 
@@ -87,10 +88,25 @@ func TestGetFailure(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:    "user validation failure: missing keys",
+			name:    "user validation failure: missing access token or github_app",
 			source:  cogito.Source{},
 			writer:  io.Discard,
-			wantErr: "get: source: missing keys: owner, repo, access_token",
+			wantErr: "get: source: one of access_token or github_app must be specified",
+		},
+		{
+			name: "user validation failure: both access_key and github_app are set",
+			source: cogito.Source{
+				AccessToken: "dummy-token",
+				GitHubApp:   github.GitHubApp{ClientId: "client-id"},
+			},
+			writer:  io.Discard,
+			wantErr: "get: source: cannot specify both github_app and access_token",
+		},
+		{
+			name:    "user validation failure: missing keys",
+			source:  cogito.Source{AccessToken: "dummy-token"},
+			writer:  io.Discard,
+			wantErr: "get: source: missing keys: owner, repo",
 		},
 		{
 			name:    "concourse validation failure: empty version field",

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -46,8 +46,10 @@ func (sink GitHubCommitStatusSink) Send() error {
 	server := github.ApiRoot(sink.Request.Source.GhHostname)
 
 	token := sink.Request.Source.AccessToken
+	// if access token is not configured, we are using github_app
+	// so we must generate the installation token
 	if token == "" {
-		installationToken, err := github.GenerateInstallationToken(server, sink.Request.Source.GitHubApp)
+		installationToken, err := github.GenerateInstallationToken(ctx, httpClient, server, sink.Request.Source.GitHubApp)
 		if err != nil {
 			return err
 		}

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -43,10 +43,20 @@ func (sink GitHubCommitStatusSink) Send() error {
 	ghState := ghAdaptState(sink.Request.Params.State)
 	buildURL := concourseBuildURL(sink.Request.Env)
 	context := ghMakeContext(sink.Request)
+	server := github.ApiRoot(sink.Request.Source.GhHostname)
+
+	token := sink.Request.Source.AccessToken
+	if token == "" {
+		installationToken, err := github.GenerateInstallationToken(server, sink.Request.Source.GitHubApp)
+		if err != nil {
+			return err
+		}
+		token = installationToken
+	}
 
 	target := &github.Target{
 		Client: httpClient,
-		Server: github.ApiRoot(sink.Request.Source.GhHostname),
+		Server: server,
 		Retry: retry.Retry{
 			FirstDelay:   retryFirstDelay,
 			BackoffLimit: retryBackoffLimit,
@@ -54,7 +64,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 			Log:          sink.Log,
 		},
 	}
-	commitStatus := github.NewCommitStatus(target, sink.Request.Source.AccessToken,
+	commitStatus := github.NewCommitStatus(target, token,
 		sink.Request.Source.Owner, sink.Request.Source.Repo, context, sink.Log)
 	description := "Build " + sink.Request.Env.BuildName
 

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -162,9 +162,14 @@ type Source struct {
 	//
 	// Mandatory
 	//
-	Owner       string `json:"owner"`
-	Repo        string `json:"repo"`
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+	// Mandatory if not using github app auth
 	AccessToken string `json:"access_token"` // SENSITIVE
+
+	// Mandatory if using github app auth
+	GitHubApp github.GitHubApp `json:"github_app,omitempty"`
+
 	//
 	// Optional
 	//
@@ -188,6 +193,9 @@ func (src Source) String() string {
 	fmt.Fprintf(&bld, "github_hostname:       %s\n", src.GhHostname)
 	fmt.Fprintf(&bld, "access_token:          %s\n", redact(src.AccessToken))
 	fmt.Fprintf(&bld, "gchat_webhook:         %s\n", redact(src.GChatWebHook))
+	fmt.Fprintf(&bld, "github_app.client_id:        %s\n", src.GitHubApp.ClientId)
+	fmt.Fprintf(&bld, "github_app.installation_id:  %d\n", src.GitHubApp.InstallationId)
+	fmt.Fprintf(&bld, "github_app.private_key:      %s\n", redact(src.GitHubApp.PrivateKey))
 	fmt.Fprintf(&bld, "log_level:             %s\n", src.LogLevel)
 	fmt.Fprintf(&bld, "context_prefix:        %s\n", src.ContextPrefix)
 	fmt.Fprintf(&bld, "omit_target_url:       %t\n", src.OmitTargetURL)
@@ -245,7 +253,18 @@ func (src *Source) Validate() error {
 		if src.Repo == "" {
 			mandatory = append(mandatory, "repo")
 		}
-		if src.AccessToken == "" {
+
+		if src.GitHubApp != (github.GitHubApp{}) {
+			if src.GitHubApp.ClientId == "" {
+				mandatory = append(mandatory, "github_app.client_id")
+			}
+			if src.GitHubApp.InstallationId == 0 {
+				mandatory = append(mandatory, "github_app.installation_id")
+			}
+			if src.GitHubApp.PrivateKey == "" {
+				mandatory = append(mandatory, "github_app.private_key")
+			}
+		} else if src.AccessToken == "" {
 			mandatory = append(mandatory, "access_token")
 		}
 	}

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -104,9 +104,22 @@ func TestSourceValidationFailure(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:    "missing mandatory git source keys",
+			name:    "access_token and github_app both missing",
 			source:  cogito.Source{},
-			wantErr: "source: missing keys: owner, repo, access_token",
+			wantErr: "source: one of access_token or github_app must be specified",
+		},
+		{
+			name: "both access_key and github_app are set",
+			source: cogito.Source{
+				AccessToken: "dummy-token",
+				GitHubApp:   github.GitHubApp{ClientId: "client-id"},
+			},
+			wantErr: "source: cannot specify both github_app and access_token",
+		},
+		{
+			name:    "missing mandatory git source keys",
+			source:  cogito.Source{AccessToken: "dummy-token"},
+			wantErr: "source: missing keys: owner, repo",
 		},
 		{
 			name: "missing mandatory git source keys for github app: client-id",

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -12,6 +12,7 @@ import (
 	"gotest.tools/v3/assert/cmp"
 
 	"github.com/Pix4D/cogito/cogito"
+	"github.com/Pix4D/cogito/github"
 	"github.com/Pix4D/cogito/testhelp"
 )
 
@@ -63,6 +64,20 @@ func TestSourceValidationSuccess(t *testing.T) {
 				return source
 			},
 		},
+		{
+			name: "git source: github app",
+			mkSource: func() cogito.Source {
+				return cogito.Source{
+					Owner: "the-owner",
+					Repo:  "the-repo",
+					GitHubApp: github.GitHubApp{
+						ClientId:       "client-id-key",
+						InstallationId: 12345,
+						PrivateKey:     "private-ssh-key",
+					},
+				}
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -92,6 +107,29 @@ func TestSourceValidationFailure(t *testing.T) {
 			name:    "missing mandatory git source keys",
 			source:  cogito.Source{},
 			wantErr: "source: missing keys: owner, repo, access_token",
+		},
+		{
+			name: "missing mandatory git source keys for github app: client-id",
+			source: cogito.Source{
+				Owner: "the-owner",
+				Repo:  "the-repo",
+				GitHubApp: github.GitHubApp{
+					InstallationId: 1234,
+					PrivateKey:     "private-rsa-key",
+				},
+			},
+			wantErr: "source: missing keys: github_app.client_id",
+		},
+		{
+			name: "missing mandatory git source keys for github app: private key",
+			source: cogito.Source{
+				Owner: "the-owner",
+				Repo:  "the-repo",
+				GitHubApp: github.GitHubApp{
+					ClientId: "client-id",
+				},
+			},
+			wantErr: "source: missing keys: github_app.installation_id, github_app.private_key",
 		},
 		{
 			name:    "missing mandatory gchat source key",
@@ -204,6 +242,7 @@ func TestSourcePrintLogRedaction(t *testing.T) {
 		Repo:               "the-repo",
 		GhHostname:         "github.com",
 		AccessToken:        "sensitive-the-access-token",
+		GitHubApp:          github.GitHubApp{ClientId: "client-id", InstallationId: 1234, PrivateKey: "sensitive-private-rsa-key"},
 		GChatWebHook:       "sensitive-gchat-webhook",
 		LogLevel:           "debug",
 		ContextPrefix:      "the-prefix",
@@ -217,6 +256,9 @@ repo:                  the-repo
 github_hostname:       github.com
 access_token:          ***REDACTED***
 gchat_webhook:         ***REDACTED***
+github_app.client_id:        client-id
+github_app.installation_id:  1234
+github_app.private_key:      ***REDACTED***
 log_level:             debug
 context_prefix:        the-prefix
 omit_target_url:       false
@@ -238,6 +280,9 @@ repo:
 github_hostname:       
 access_token:          
 gchat_webhook:         
+github_app.client_id:        
+github_app.installation_id:  0
+github_app.private_key:      
 log_level:             
 context_prefix:        
 omit_target_url:       false

--- a/cogito/put_test.go
+++ b/cogito/put_test.go
@@ -172,9 +172,35 @@ func TestPutterLoadConfigurationFailure(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:     "source: missing keys",
-			putInput: cogito.PutRequest{Source: cogito.Source{}, Params: baseParams},
-			wantErr:  "put: source: missing keys: owner, repo, access_token",
+			name: "source: both access_key and github_app are set",
+			putInput: cogito.PutRequest{
+				Source: cogito.Source{
+					AccessToken: "dummy-token",
+					GitHubApp: github.GitHubApp{
+						InstallationId: 1234,
+					},
+				},
+				Params: baseParams,
+			},
+			wantErr: "put: source: cannot specify both github_app and access_token",
+		},
+		{
+			name: "source: missing access token or github_app",
+			putInput: cogito.PutRequest{
+				Source: cogito.Source{},
+				Params: baseParams,
+			},
+			wantErr: "put: source: one of access_token or github_app must be specified",
+		},
+		{
+			name: "source: missing keys",
+			putInput: cogito.PutRequest{
+				Source: cogito.Source{
+					AccessToken: "dummy-token",
+				},
+				Params: baseParams,
+			},
+			wantErr: "put: source: missing keys: owner, repo",
 		},
 		{
 			name: "params: invalid",

--- a/github/githubapp.go
+++ b/github/githubapp.go
@@ -1,0 +1,96 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type GitHubApp struct {
+	ClientId       string `json:"client_id"`
+	InstallationId int64  `json:"installation_id"`
+	PrivateKey     string `json:"private_key"` // SENSITIVE
+}
+
+// generateJWTtoken returns a signed JWT token used to authenticate as GitHub App
+func generateJWTtoken(clientId, privateKey string) (string, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(privateKey))
+	if err != nil {
+		return "", fmt.Errorf("could not parse private key: %w", err)
+	}
+	// GitHub rejects expiry and issue timestamps that are not an integer,
+	// while the jwt-go library serializes to fractional timestamps.
+	// Truncate them before passing to jwt-go.
+	// Additionally, GitHub recommends setting this value 60 seconds in the past.
+	iat := time.Now().Add(-60 * time.Second).Truncate(time.Second)
+	// maximum validity 10 minutes. Here, we reduce it to 2 minutes.
+	exp := iat.Add(2 * time.Minute)
+	// Docs: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts
+	claims := &jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(iat),
+		ExpiresAt: jwt.NewNumericDate(exp),
+		// The client ID or application ID of your GitHub App.
+		// Use of the client ID is recommended.
+		Issuer: clientId,
+	}
+
+	// GitHub JWT must be signed using the RS256 algorithm.
+	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("could not sign the JWT token: %w", err)
+	}
+	return token, nil
+}
+
+// GenerateInstallationToken returns an installation token used to authenticate as GitHub App installation
+func GenerateInstallationToken(server string, app GitHubApp) (string, error) {
+	// API: POST /app/installations/{installationId}/access_tokens
+	installationId := strconv.FormatInt(app.InstallationId, 10)
+	url := server + path.Join("/app/installations", installationId, "/access_tokens")
+
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("github post: new request: %s", err)
+	}
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+
+	jtwToken, err := generateJWTtoken(app.ClientId, app.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+jtwToken)
+
+	client := &http.Client{Timeout: time.Second * 5}
+
+	// FIXME: add retry here...
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("http client Do: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, errBody := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		if errBody != nil {
+			return "", fmt.Errorf("generate github app installation token: status code: %d (%s)", resp.StatusCode, errBody)
+		}
+		return "", fmt.Errorf("generate github app installation token: status code: %d (%s)", resp.StatusCode, string(body))
+	}
+	if errBody != nil {
+		return string(body), fmt.Errorf("generate github app installation token: read body: %s", errBody)
+	}
+
+	var token struct {
+		Value string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &token); err != nil {
+		return "", fmt.Errorf("error: json unmarshal: %s", err)
+	}
+	return token.Value, nil
+}

--- a/github/githubapp_test.go
+++ b/github/githubapp_test.go
@@ -1,0 +1,52 @@
+package github_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Pix4D/cogito/github"
+	"github.com/Pix4D/cogito/testhelp"
+	"gotest.tools/v3/assert"
+)
+
+func TestGenerateInstallationToken(t *testing.T) {
+	clientID := "abcd1234"
+	var installationID int64 = 12345
+
+	privateKey, err := testhelp.GeneratePrivateKey(t, 2048)
+	assert.NilError(t, err)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			fmt.Fprintln(w, "wrong HTTP method")
+			return
+		}
+
+		claims := testhelp.DecodeJWT(t, r, privateKey)
+		if claims.Issuer != clientID {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintln(w, "unauthorized: wrong JWT token")
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintln(w, `{"token": "dummy_installation_token"}`)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	gotToken, err := github.GenerateInstallationToken(
+		ts.URL,
+		github.GitHubApp{
+			ClientId:       clientID,
+			InstallationId: installationID,
+			PrivateKey:     string(testhelp.EncodePrivateKeyToPEM(privateKey)),
+		},
+	)
+
+	assert.NilError(t, err)
+	assert.Equal(t, "dummy_installation_token", gotToken)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/alexflint/go-arg v1.4.3
 	github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6
-	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-cmp v0.6.0
 	github.com/sasbury/mini v0.0.0-20181226232755-dc74af49394b
 	gotest.tools/v3 v3.5.1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/alexflint/go-arg v1.4.3
 	github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.6.0
 	github.com/sasbury/mini v0.0.0-20181226232755-dc74af49394b
 	gotest.tools/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/testhelp/testhelper.go
+++ b/testhelp/testhelper.go
@@ -2,10 +2,15 @@ package testhelp
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -14,6 +19,7 @@ import (
 	"text/template"
 
 	"dario.cat/mergo"
+	"github.com/golang-jwt/jwt/v4"
 	"gotest.tools/v3/assert"
 )
 
@@ -145,10 +151,13 @@ func copyFile(dstPath string, srcPath string, templatedata TemplateData) error {
 // GhTestCfg contains the secrets needed to run integration tests against the
 // GitHub Commit Status API.
 type GhTestCfg struct {
-	Token string
-	Owner string
-	Repo  string
-	SHA   string
+	Token               string
+	GhAppClientID       string
+	GhAppInstallationID string
+	GhAppPrivateKey     string
+	Owner               string
+	Repo                string
+	SHA                 string
 }
 
 // FakeTestCfg is a fake test configuration that can be used in some tests that need
@@ -166,10 +175,13 @@ func GitHubSecretsOrFail(t *testing.T) GhTestCfg {
 	t.Helper()
 
 	return GhTestCfg{
-		Token: getEnvOrFail(t, "COGITO_TEST_OAUTH_TOKEN"),
-		Owner: getEnvOrFail(t, "COGITO_TEST_REPO_OWNER"),
-		Repo:  getEnvOrFail(t, "COGITO_TEST_REPO_NAME"),
-		SHA:   getEnvOrFail(t, "COGITO_TEST_COMMIT_SHA"),
+		Token:               getEnvOrFail(t, "COGITO_TEST_OAUTH_TOKEN"),
+		GhAppClientID:       getEnvOrFail(t, "COGITO_TEST_GH_APP_CLIENT_ID"),
+		GhAppInstallationID: getEnvOrFail(t, "COGITO_TEST_GH_APP_INSTALLATION_ID"),
+		GhAppPrivateKey:     getEnvOrFail(t, "COGITO_TEST_GH_APP_PRIVATE_KEY"),
+		Owner:               getEnvOrFail(t, "COGITO_TEST_REPO_OWNER"),
+		Repo:                getEnvOrFail(t, "COGITO_TEST_REPO_NAME"),
+		SHA:                 getEnvOrFail(t, "COGITO_TEST_COMMIT_SHA"),
 	}
 }
 
@@ -292,4 +304,47 @@ type FailingWriter struct{}
 
 func (t *FailingWriter) Write([]byte) (n int, err error) {
 	return 0, errors.New("test write error")
+}
+
+// GeneratePrivateKey creates a RSA Private Key of specified byte size
+func GeneratePrivateKey(t *testing.T, bitSize int) (*rsa.PrivateKey, error) {
+	// Private Key generation
+	privateKey, err := rsa.GenerateKey(rand.Reader, bitSize)
+	assert.NilError(t, err)
+
+	// Validate Private Key
+	err = privateKey.Validate()
+	assert.NilError(t, err)
+
+	return privateKey, nil
+}
+
+// EncodePrivateKeyToPEM encodes Private Key from RSA to PEM format
+func EncodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
+	// Get ASN.1 DER format
+	privDER := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	// pem.Block
+	privBlock := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privDER,
+	}
+
+	return pem.EncodeToMemory(&privBlock)
+}
+
+// DecodeJWT decodes the HTTP request authorization header with the given RSA key
+// and returns the registered claims of the decoded token.
+func DecodeJWT(t *testing.T, r *http.Request, key *rsa.PrivateKey) *jwt.RegisteredClaims {
+	token := strings.Fields(r.Header.Get("Authorization"))[1]
+	tok, err := jwt.ParseWithClaims(token, &jwt.RegisteredClaims{}, func(t *jwt.Token) (interface{}, error) {
+		if t.Header["alg"] != "RS256" {
+			return nil, fmt.Errorf("unexpected signing method: %v, expected: %v", t.Header["alg"], "RS256")
+		}
+		return &key.PublicKey, nil
+	})
+	assert.NilError(t, err)
+
+	return tok.Claims.(*jwt.RegisteredClaims)
 }

--- a/testhelp/testhelper.go
+++ b/testhelp/testhelper.go
@@ -19,7 +19,7 @@ import (
 	"text/template"
 
 	"dario.cat/mergo"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"gotest.tools/v3/assert"
 )
 


### PR DESCRIPTION
GitHub: add support for GitHub apps

Docker image available for testing: `pix4d/cogito:pci-4263-support-github-apps`

Passes all integration and acceptance tests in CI pipeline...

It's still a draft because there are still some things to polish like:
- ~~update docs about github app, increased rate limit and how to configure it~~
- ~~private_key: multiline or base64 encoded? so far, seems fine with multiline...~~
- ~~print in logs rate limit after each request (at least in debug)~~
- ~~update acceptance tests pipelines according to our OPA rules~~
- ~~update pipeline with acceptance tests for github app~~
- maybe implement retry on a POST HTTP request that fetches the installation token
etc...

Some stuff from the list above are optional, some required, like updating docs, but since this PR is fully functional already, I would like to start collecting review feedback.

Basically, it replaces: https://github.com/Pix4D/cogito/pull/161 and closes: https://github.com/Pix4D/cogito/issues/151

