### PR TITLE
log http request info (duration, rate limit data)

### DIFF
--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -50,7 +50,7 @@ func (sink GoogleChatSink) Send() error {
 	threadKey := fmt.Sprintf("%s %s", sink.Request.Env.BuildPipelineName, sink.GitRef)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	reply, err := googlechat.TextMessage(ctx, webHook, threadKey, text)
+	reply, err := googlechat.TextMessage(ctx, sink.Log, webHook, threadKey, text)
 	if err != nil {
 		return fmt.Errorf("GoogleChatSink: %s", err)
 	}

--- a/github/commitstatus.go
+++ b/github/commitstatus.go
@@ -69,7 +69,11 @@ type CommitStatus struct {
 //
 // See also:
 // - https://docs.github.com/en/rest/commits/statuses
-func NewCommitStatus(target *Target, token, owner, repo, context string, log *slog.Logger) CommitStatus {
+func NewCommitStatus(
+	target *Target,
+	token, owner, repo, context string,
+	log *slog.Logger,
+) CommitStatus {
 	return CommitStatus{
 		target:  target,
 		token:   token,
@@ -140,7 +144,16 @@ func (cs CommitStatus) Add(sha, state, targetURL, description string) error {
 		remaining := resp.Header.Get("X-RateLimit-Remaining")
 		limit := resp.Header.Get("X-RateLimit-Limit")
 		reset := resp.Header.Get("X-RateLimit-Reset")
-		cs.log.Debug("http-request", "method", req.Method, "url", req.URL, "status", resp.StatusCode, "duration", elapsed, "rate-limit", limit, "rate-limit-remaining", remaining, "rate-limit-reset", reset)
+		cs.log.Debug(
+			"http-request",
+			"method", req.Method,
+			"url", req.URL,
+			"status", resp.StatusCode,
+			"duration", elapsed,
+			"rate-limit", limit,
+			"rate-limit-remaining", remaining,
+			"rate-limit-reset", reset,
+		)
 
 		if resp.StatusCode == http.StatusCreated {
 			return nil
@@ -162,7 +175,11 @@ func (cs CommitStatus) Add(sha, state, targetURL, description string) error {
 // and used by other tools, so we must not merge hints specific to the
 // Commit Status API.
 func (cs CommitStatus) explainError(err error, state, sha, url string) error {
-	commonWhat := fmt.Sprintf("failed to add state %q for commit %s", state, sha[0:min(len(sha), 7)])
+	commonWhat := fmt.Sprintf(
+		"failed to add state %q for commit %s",
+		state,
+		sha[0:min(len(sha), 7)],
+	)
 	var ghErr GitHubError
 	if errors.As(err, &ghErr) {
 		hint := "none"
@@ -179,7 +196,10 @@ func (cs CommitStatus) explainError(err error, state, sha, url string) error {
 			hint = "Either wrong credentials or PAT expired (check your email for expiration notice)"
 		case http.StatusForbidden:
 			if ghErr.RateLimitRemaining == 0 {
-				hint = fmt.Sprintf("Rate limited but the wait time to reset would be longer than %v (Retry.UpTo)", cs.target.Retry.UpTo)
+				hint = fmt.Sprintf(
+					"Rate limited but the wait time to reset would be longer than %v (Retry.UpTo)",
+					cs.target.Retry.UpTo,
+				)
 			}
 		}
 		return &StatusError{

--- a/googlechat/googlechat.go
+++ b/googlechat/googlechat.go
@@ -71,7 +71,11 @@ type MessageSpace struct {
 // webhooks: https://developers.google.com/chat/how-tos/webhooks
 // payload: https://developers.google.com/chat/api/guides/message-formats/basic
 // threadKey: https://developers.google.com/chat/reference/rest/v1/spaces.messages/create
-func TextMessage(ctx context.Context, log *slog.Logger, theURL, threadKey, text string) (MessageReply, error) {
+func TextMessage(
+	ctx context.Context,
+	log *slog.Logger,
+	theURL, threadKey, text string,
+) (MessageReply, error) {
 	body, err := json.Marshal(BasicMessage{Text: text})
 	if err != nil {
 		return MessageReply{}, fmt.Errorf("TextMessage: %s", err)
@@ -100,7 +104,13 @@ func TextMessage(ctx context.Context, log *slog.Logger, theURL, threadKey, text 
 	}
 	defer resp.Body.Close()
 	elapsed := time.Since(start)
-	log.Debug("http-request", "method", req.Method, "url", req.URL, "status", resp.StatusCode, "duration", elapsed)
+	log.Debug(
+		"http-request",
+		"method", req.Method,
+		"url", req.URL,
+		"status", resp.StatusCode,
+		"duration", elapsed,
+	)
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/googlechat/googlechat_test.go
+++ b/googlechat/googlechat_test.go
@@ -12,9 +12,11 @@ import (
 	"gotest.tools/v3/assert/cmp"
 
 	"github.com/Pix4D/cogito/googlechat"
+	"github.com/Pix4D/cogito/testhelp"
 )
 
 func TestTextMessageIntegration(t *testing.T) {
+	log := testhelp.MakeTestLog()
 	gchatUrl := os.Getenv("COGITO_TEST_GCHAT_HOOK")
 	if len(gchatUrl) == 0 {
 		t.Skip("Skipping integration test. See CONTRIBUTING for how to enable.")
@@ -30,7 +32,7 @@ func TestTextMessageIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	reply, err := googlechat.TextMessage(ctx, gchatUrl, threadKey, text)
+	reply, err := googlechat.TextMessage(ctx, log, gchatUrl, threadKey, text)
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Contains(reply.Text, text))


### PR DESCRIPTION
log http request info (duration, rate limit data)

For Gchat sink we can extend the log with rate limit data when we tackle: https://pix4dbug.atlassian.net/browse/PCI-4096
