### PR TITLE
replace .invalid domain name with .example

### DIFF
--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -121,7 +121,7 @@ func TestRunPutSuccessIntegration(t *testing.T) {
 		testhelp.HttpsRemote(github.GhDefaultHostname, gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
 		"ref: refs/heads/a-branch-FIXME")
 	t.Setenv("BUILD_JOB_NAME", "TestRunPutSuccessIntegration")
-	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.invalid")
+	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.example")
 	t.Setenv("BUILD_PIPELINE_NAME", "the-test-pipeline")
 	t.Setenv("BUILD_TEAM_NAME", "the-test-team")
 	t.Setenv("BUILD_NAME", "42")
@@ -163,7 +163,7 @@ func TestRunPutGhAppSuccessIntegration(t *testing.T) {
 		testhelp.HttpsRemote(github.GhDefaultHostname, gitHubCfg.Owner, gitHubCfg.Repo), gitHubCfg.SHA,
 		"ref: refs/heads/a-branch-FIXME")
 	t.Setenv("BUILD_JOB_NAME", "TestRunPutGhAppSuccessIntegration")
-	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.invalid")
+	t.Setenv("ATC_EXTERNAL_URL", "https://cogito.example")
 	t.Setenv("BUILD_PIPELINE_NAME", "the-test-pipeline")
 	t.Setenv("BUILD_TEAM_NAME", "the-test-team")
 	t.Setenv("BUILD_NAME", "42")

--- a/cogito/gchatsink_private_test.go
+++ b/cogito/gchatsink_private_test.go
@@ -220,7 +220,7 @@ func TestGChatBuildSummaryText(t *testing.T) {
 		BuildName:         "42",
 		BuildJobName:      "the-job",
 		BuildPipelineName: "the-pipeline",
-		AtcExternalUrl:    "https://cogito.invalid",
+		AtcExternalUrl:    "https://cogito.example",
 	}
 
 	have := gChatBuildSummaryText(commit, state, src, env)

--- a/cogito/gchatsink_test.go
+++ b/cogito/gchatsink_test.go
@@ -99,7 +99,7 @@ func TestSinkGoogleChatDecidesNotToSendSuccess(t *testing.T) {
 		{
 			name: "state not in enabled states",
 			request: cogito.PutRequest{
-				Source: cogito.Source{GChatWebHook: "https://cogito.invalid"},
+				Source: cogito.Source{GChatWebHook: "https://cogito.example"},
 				Params: cogito.PutParams{State: cogito.StatePending}, // not sent by default
 			},
 		},

--- a/github/commitstatus_test.go
+++ b/github/commitstatus_test.go
@@ -59,7 +59,7 @@ func TestGitHubStatusSuccessMockAPI(t *testing.T) {
 
 	cfg := testhelp.FakeTestCfg
 	context := "cogito/test"
-	targetURL := "https://cogito.invalid/builds/job/42"
+	targetURL := "https://cogito.example/builds/job/42"
 	now := time.Now()
 	desc := now.Format("15:04:05")
 
@@ -198,7 +198,7 @@ func TestGitHubStatusFailureMockAPI(t *testing.T) {
 
 	cfg := testhelp.FakeTestCfg
 	context := "cogito/test"
-	targetURL := "https://cogito.invalid/builds/job/42"
+	targetURL := "https://cogito.example/builds/job/42"
 	now := time.Now()
 	desc := now.Format("15:04:05")
 	upTo := 5 * time.Minute
@@ -332,7 +332,7 @@ func TestGitHubStatusSuccessIntegration(t *testing.T) {
 
 	cfg := testhelp.GitHubSecretsOrFail(t)
 	context := "cogito/test"
-	targetURL := "https://cogito.invalid/builds/job/42"
+	targetURL := "https://cogito.example/builds/job/42"
 	desc := time.Now().Format("15:04:05")
 	state := "success"
 	log := testhelp.MakeTestLog()


### PR DESCRIPTION
- replace `.invalid` domain name with `.example`

Addresses the comment in previous PR: https://github.com/Pix4D/cogito/pull/162#discussion_r2069896024