### PR TITLE
googlechat: retry on temporary failures and on timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to Go 1.26.2
+- Function `googlechat.TextMessage` now retries transient errors and client timeouts.
+
+### Breaking changes
+
+- Change signature of function `googlechat.TextMessage`; it now supports retry and per-request timeout.
+  See file `googlechat/googlechat_test.go` for how to invoke it.
 
 ## [v0.15.0] - 2026-01-27
 

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -51,7 +51,8 @@ func (sink GoogleChatSink) Send() error {
 	threadKey := fmt.Sprintf("%s %s", sink.Request.Env.BuildPipelineName, sink.GitRef)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	reply, err := googlechat.TextMessage(ctx, sink.Log, webHook, threadKey, text)
+	reply, err := googlechat.TextMessage(ctx, sink.Log, googlechat.DefaultRetry(sink.Log),
+		webHook, threadKey, text)
 	if err != nil {
 		return fmt.Errorf("GoogleChatSink: %s", err)
 	}

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -1,7 +1,6 @@
 package cogito
 
 import (
-	"context"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -49,10 +48,8 @@ func (sink GoogleChatSink) Send() error {
 	}
 
 	threadKey := fmt.Sprintf("%s %s", sink.Request.Env.BuildPipelineName, sink.GitRef)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	reply, err := googlechat.TextMessage(ctx, sink.Log, googlechat.DefaultRetry(sink.Log),
-		webHook, threadKey, text)
+	reply, err := googlechat.TextMessage(sink.Log, googlechat.DefaultRetry(sink.Log),
+		googlechat.DefaultTimeout, webHook, threadKey, text)
 	if err != nil {
 		return fmt.Errorf("GoogleChatSink: %s", err)
 	}

--- a/cogito/gchatsink_test.go
+++ b/cogito/gchatsink_test.go
@@ -1,3 +1,7 @@
+// This file tests the integration of Google Chat as a Cogito sink.
+// See also file googlechat/googlechat_test.go for tests of Google Chat independently
+// from Cogito.
+
 package cogito_test
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	dario.cat/mergo v1.0.0
-	github.com/Pix4D/go-kit v0.2.0
+	github.com/Pix4D/go-kit v0.2.1-0.20260408084514-4ad142f0682f
 	github.com/alexflint/go-arg v1.4.3
 	github.com/sasbury/mini v0.0.0-20181226232755-dc74af49394b
 	gotest.tools/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Pix4D/go-kit v0.2.0 h1:da3Ya9rKuYVOjKUDEBh5T93RSX41xZiwsfwj9js8Hhs=
-github.com/Pix4D/go-kit v0.2.0/go.mod h1:79yrn4vFsZ4x375MC8bauJdWfJeytI5f4Dde9SJUNGQ=
+github.com/Pix4D/go-kit v0.2.1-0.20260408084514-4ad142f0682f h1:53MDtG8uUG39VFSQ93FJb4kdCqr0cFhT44LXsu/vnnw=
+github.com/Pix4D/go-kit v0.2.1-0.20260408084514-4ad142f0682f/go.mod h1:Qod5jEq+d4hsMbzBXVTNpg0YRU918idXJs7EAOoPD8A=
 github.com/alexflint/go-arg v1.4.3 h1:9rwwEBpMXfKQKceuZfYcwuc/7YY7tWJbFsgG5cAU/uo=
 github.com/alexflint/go-arg v1.4.3/go.mod h1:3PZ/wp/8HuqRZMUUgu7I+e1qcpUbvmS258mRXkFH4IA=
 github.com/alexflint/go-scalar v1.1.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=

--- a/googlechat/googlechat.go
+++ b/googlechat/googlechat.go
@@ -14,8 +14,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/Pix4D/go-kit/retry"
 )
 
 // BasicMessage is the request for a Google Chat basic message.
@@ -57,8 +60,22 @@ type MessageSpace struct {
 	DisplayName string `json:"displayName"` // Name of the space in the UI.
 }
 
+// DefaultRetry returns a [retry.Retry] with the recommended values to be passed to
+// [TextMessage] for production. If you have special requirements, or for testing,
+// you can override completely or partially.
+func DefaultRetry(log *slog.Logger) retry.Retry {
+	upTo := 60 * time.Second
+	return retry.Retry{
+		UpTo:         upTo,
+		FirstDelay:   1 * time.Second,
+		BackoffLimit: upTo / 4,
+		Log:          log,
+	}
+}
+
 // TextMessage sends the one-off message `text` with `threadKey` to webhook `theURL` and
 // returns an abridged response.
+// Use [DefaultRetry] for parameter 'rtr'.
 //
 // Note that the Google Chat API encodes the secret in the webhook itself.
 //
@@ -74,6 +91,7 @@ type MessageSpace struct {
 func TextMessage(
 	ctx context.Context,
 	log *slog.Logger,
+	rtr retry.Retry,
 	webHook, threadKey, text string,
 ) (MessageReply, error) {
 	body, err := json.Marshal(BasicMessage{Text: text})
@@ -81,26 +99,10 @@ func TextMessage(
 		return MessageReply{}, fmt.Errorf("TextMessage: %s", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webHook,
-		bytes.NewBuffer(body))
-	if err != nil {
-		return MessageReply{},
-			fmt.Errorf("TextMessage: new request: %w", RedactErrorURL(err))
-	}
-	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-
-	// Encode the thread Key a URL parameter.
-	if threadKey != "" {
-		values := req.URL.Query()
-		values.Set("threadKey", threadKey)
-		req.URL.RawQuery = values.Encode()
-	}
-
-	client := &http.Client{}
 	start := time.Now()
-	resp, err := client.Do(req)
+	resp, err := retrySend(rtr, webHook, threadKey, body)
 	if err != nil {
-		return MessageReply{}, fmt.Errorf("TextMessage: send: %s", RedactErrorURL(err))
+		return MessageReply{}, fmt.Errorf("TextMessage: retrySend: %s", RedactErrorURL(err))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -108,19 +110,18 @@ func TextMessage(
 		}
 	}()
 	elapsed := time.Since(start)
+	redacted := RedactURL(resp.Request.URL)
 	log.Debug(
 		"http-request",
-		"method", req.Method,
-		"url", req.URL,
+		"url", redacted,
 		"status", resp.StatusCode,
 		"duration", elapsed,
 	)
-
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		return MessageReply{},
 			fmt.Errorf("TextMessage: status: %s; URL: %s; body: %s",
-				resp.Status, RedactURL(req.URL), strings.TrimSpace(string(respBody)))
+				resp.Status, redacted, strings.TrimSpace(string(respBody)))
 	}
 
 	var reply MessageReply
@@ -131,6 +132,55 @@ func TextMessage(
 	}
 
 	return reply, nil
+}
+
+// From the curl --retry manual page:
+// > Transient error means either: a timeout, an FTP 4xx response code or an
+// > HTTP 408, 429, 500, 502, 503 or 504 response code.
+var retryables = []int{
+	http.StatusRequestTimeout,      // 408
+	http.StatusTooManyRequests,     // 429
+	http.StatusInternalServerError, // 500
+	http.StatusBadGateway,          // 502
+	http.StatusServiceUnavailable,  // 503
+	// Not safe for requests that change state and are not idempotent.
+	// http.StatusGatewayTimeout,      // 504
+}
+
+func retrySend(rtr retry.Retry, webHook, threadKey string, body []byte) (*http.Response, error) {
+	var resp *http.Response
+	client := &http.Client{}
+	workFn := func() error {
+		var err error
+		req, err := http.NewRequest(http.MethodPost, webHook, bytes.NewBuffer(body))
+		if err != nil {
+			return fmt.Errorf("TextMessage: new request: %w", RedactErrorURL(err))
+		}
+		req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+		// Encode the thread Key as a URL parameter.
+		if threadKey != "" {
+			values := req.URL.Query()
+			values.Set("threadKey", threadKey)
+			req.URL.RawQuery = values.Encode()
+		}
+		resp, err = client.Do(req)
+		return err
+	}
+	classifierFn := func(err error) retry.Action {
+		if err != nil {
+			return retry.HardFail
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			return retry.Success
+		}
+		if slices.Contains(retryables, resp.StatusCode) {
+			return retry.SoftFail
+		}
+		return retry.HardFail
+	}
+
+	err := rtr.Do(retry.ExponentialBackoff, classifierFn, workFn)
+	return resp, err
 }
 
 // RedactURL returns a _best effort_ redacted copy of theURL.

--- a/googlechat/googlechat.go
+++ b/googlechat/googlechat.go
@@ -74,14 +74,14 @@ type MessageSpace struct {
 func TextMessage(
 	ctx context.Context,
 	log *slog.Logger,
-	theURL, threadKey, text string,
+	webHook, threadKey, text string,
 ) (MessageReply, error) {
 	body, err := json.Marshal(BasicMessage{Text: text})
 	if err != nil {
 		return MessageReply{}, fmt.Errorf("TextMessage: %s", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, theURL,
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webHook,
 		bytes.NewBuffer(body))
 	if err != nil {
 		return MessageReply{},

--- a/googlechat/googlechat.go
+++ b/googlechat/googlechat.go
@@ -73,9 +73,15 @@ func DefaultRetry(log *slog.Logger) retry.Retry {
 	}
 }
 
+// DefaultTimeout is the recommended per-retry timeout value to be passed to [TextMessage]
+// for production. If you have special requirements, or for testing, you can override.
+const DefaultTimeout = 5 * time.Second
+
 // TextMessage sends the one-off message `text` with `threadKey` to webhook `theURL` and
 // returns an abridged response.
-// Use [DefaultRetry] for parameter 'rtr'.
+//
+//   - Use [DefaultRetry] for parameter 'rtr'.
+//   - Use [DefaultTimeout] for parameter 'timeout' (per-request timeout).
 //
 // Note that the Google Chat API encodes the secret in the webhook itself.
 //
@@ -89,9 +95,9 @@ func DefaultRetry(log *slog.Logger) retry.Retry {
 // payload: https://developers.google.com/chat/api/guides/message-formats/basic
 // threadKey: https://developers.google.com/chat/reference/rest/v1/spaces.messages/create
 func TextMessage(
-	ctx context.Context,
 	log *slog.Logger,
 	rtr retry.Retry,
+	timeout time.Duration,
 	webHook, threadKey, text string,
 ) (MessageReply, error) {
 	body, err := json.Marshal(BasicMessage{Text: text})
@@ -100,7 +106,7 @@ func TextMessage(
 	}
 
 	start := time.Now()
-	resp, err := retrySend(rtr, webHook, threadKey, body)
+	resp, err := retrySend(rtr, timeout, webHook, threadKey, body)
 	if err != nil {
 		return MessageReply{}, fmt.Errorf("TextMessage: retrySend: %s", RedactErrorURL(err))
 	}
@@ -147,12 +153,17 @@ var retryables = []int{
 	// http.StatusGatewayTimeout,      // 504
 }
 
-func retrySend(rtr retry.Retry, webHook, threadKey string, body []byte) (*http.Response, error) {
+func retrySend(rtr retry.Retry, timeout time.Duration, webHook, threadKey string,
+	body []byte,
+) (*http.Response, error) {
 	var resp *http.Response
 	client := &http.Client{}
 	workFn := func() error {
 		var err error
-		req, err := http.NewRequest(http.MethodPost, webHook, bytes.NewBuffer(body))
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, webHook,
+			bytes.NewBuffer(body))
 		if err != nil {
 			return fmt.Errorf("TextMessage: new request: %w", RedactErrorURL(err))
 		}
@@ -167,6 +178,9 @@ func retrySend(rtr retry.Retry, webHook, threadKey string, body []byte) (*http.R
 		return err
 	}
 	classifierFn := func(err error) retry.Action {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return retry.SoftFail
+		}
 		if err != nil {
 			return retry.HardFail
 		}

--- a/googlechat/googlechat_test.go
+++ b/googlechat/googlechat_test.go
@@ -35,24 +35,71 @@ func TestTextMessageIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	reply, err := googlechat.TextMessage(ctx, log, gchatUrl, threadKey, text)
+	reply, err := googlechat.TextMessage(ctx, log, googlechat.DefaultRetry(log),
+		gchatUrl, threadKey, text)
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Contains(reply.Text, text))
 }
 
-func TestTextMessageFailDueToStatusCode(t *testing.T) {
-	ts := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(http.StatusTeapot)
-		}))
-	defer ts.Close()
+func TestTextMessageRetryDueToStatusCodeAndPass(t *testing.T) {
 	log := testhelp.MakeTestLog()
-	ctx := context.Background()
+	var sleepsCountSpy int
+	rtr := googlechat.DefaultRetry(log)
+	rtr.SleepFn = func(d time.Duration) { sleepsCountSpy++ }
 
-	_, err := googlechat.TextMessage(ctx, log, ts.URL, "key", "bananas are ripe")
+	test := func(codes []int, wantSleeps int) {
+		t.Helper()
+		sleepsCountSpy = 0
+		ts := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if len(codes) == 0 {
+					t.Fatalf("fake server: no more status codes left")
+				}
+				var code int
+				code, codes = codes[0], codes[1:]
+				w.WriteHeader(code)
+				w.Write([]byte("{}")) //nolint:errcheck
+			}))
+		defer ts.Close()
+		fixme := context.Background()
 
-	assert.ErrorContains(t, err, "TextMessage: status: 418 I'm a teapot")
+		_, err := googlechat.TextMessage(fixme, log, rtr, ts.URL, "key", "bananas are ripe")
+
+		assert.NilError(t, err)
+		assert.Equal(t, sleepsCountSpy, wantSleeps)
+	}
+
+	test([]int{http.StatusOK}, 0)
+	test([]int{http.StatusTooManyRequests, http.StatusOK}, 1)
+	test([]int{http.StatusTooManyRequests, http.StatusTooManyRequests, http.StatusOK}, 2)
+}
+
+func TestTextMessageRetryDueToStatusCodeAndFail(t *testing.T) {
+	log := testhelp.MakeTestLog()
+	var sleepTimeSpy time.Duration
+	rtr := googlechat.DefaultRetry(log)
+	rtr.SleepFn = func(d time.Duration) { sleepTimeSpy += d }
+
+	test := func(code int, wantSlept time.Duration) {
+		t.Helper()
+		sleepTimeSpy = 0
+		ts := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(code)
+			}))
+		defer ts.Close()
+		fixme := context.Background()
+
+		_, err := googlechat.TextMessage(fixme, log, rtr, ts.URL, "key", "bananas are ripe")
+
+		assert.ErrorContains(t, err, http.StatusText(code))
+		assert.Equal(t, sleepTimeSpy, wantSlept)
+	}
+
+	test(http.StatusForbidden, 0)                 // not retriable: fails immediately.
+	test(http.StatusTooManyRequests, rtr.UpTo)    // retriable; fails after consuming all retries.
+	test(http.StatusServiceUnavailable, rtr.UpTo) // retriable; fails after consuming all retries.
 }
 
 func TestRedactURL(t *testing.T) {

--- a/googlechat/googlechat_test.go
+++ b/googlechat/googlechat_test.go
@@ -1,7 +1,6 @@
 package googlechat_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -32,11 +31,9 @@ func TestTextMessageIntegration(t *testing.T) {
 	threadKey := "banana-" + user
 	text := fmt.Sprintf("%s message oink! 🐷 sent to thread %s by user %s",
 		ts, threadKey, user)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
-	reply, err := googlechat.TextMessage(ctx, log, googlechat.DefaultRetry(log),
-		gchatUrl, threadKey, text)
+	reply, err := googlechat.TextMessage(log, googlechat.DefaultRetry(log),
+		googlechat.DefaultTimeout, gchatUrl, threadKey, text)
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Contains(reply.Text, text))
@@ -62,9 +59,9 @@ func TestTextMessageRetryDueToStatusCodeAndPass(t *testing.T) {
 				w.Write([]byte("{}")) //nolint:errcheck
 			}))
 		defer ts.Close()
-		fixme := context.Background()
 
-		_, err := googlechat.TextMessage(fixme, log, rtr, ts.URL, "key", "bananas are ripe")
+		_, err := googlechat.TextMessage(log, rtr, googlechat.DefaultTimeout, ts.URL,
+			"key", "bananas are ripe")
 
 		assert.NilError(t, err)
 		assert.Equal(t, sleepsCountSpy, wantSleeps)
@@ -89,9 +86,9 @@ func TestTextMessageRetryDueToStatusCodeAndFail(t *testing.T) {
 				w.WriteHeader(code)
 			}))
 		defer ts.Close()
-		fixme := context.Background()
 
-		_, err := googlechat.TextMessage(fixme, log, rtr, ts.URL, "key", "bananas are ripe")
+		_, err := googlechat.TextMessage(log, rtr, googlechat.DefaultTimeout, ts.URL,
+			"key", "bananas are ripe")
 
 		assert.ErrorContains(t, err, http.StatusText(code))
 		assert.Equal(t, sleepTimeSpy, wantSlept)
@@ -100,6 +97,38 @@ func TestTextMessageRetryDueToStatusCodeAndFail(t *testing.T) {
 	test(http.StatusForbidden, 0)                 // not retriable: fails immediately.
 	test(http.StatusTooManyRequests, rtr.UpTo)    // retriable; fails after consuming all retries.
 	test(http.StatusServiceUnavailable, rtr.UpTo) // retriable; fails after consuming all retries.
+}
+
+func TestTextMessageRetryDueToRequestTimeout(t *testing.T) {
+	log := testhelp.MakeTestLog()
+	var sleepsCountSpy int
+	rtr := googlechat.DefaultRetry(log)
+	rtr.SleepFn = func(d time.Duration) { sleepsCountSpy++ }
+	const timeout = 10 * time.Millisecond
+
+	test := func(failingReqs, wantSleeps int) {
+		t.Helper()
+		sleepsCountSpy = 0
+		ts := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if failingReqs > 0 {
+					failingReqs--
+					time.Sleep(10 * timeout)
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("{}")) //nolint:errcheck
+			}))
+		defer ts.Close()
+
+		_, err := googlechat.TextMessage(log, rtr, timeout, ts.URL, "key", "bananas")
+
+		assert.NilError(t, err)
+		assert.Equal(t, sleepsCountSpy, wantSleeps)
+	}
+
+	test(0, 0)
+	test(1, 1)
+	test(5, 5)
 }
 
 func TestRedactURL(t *testing.T) {

--- a/googlechat/googlechat_test.go
+++ b/googlechat/googlechat_test.go
@@ -3,6 +3,8 @@ package googlechat_test
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -37,6 +39,20 @@ func TestTextMessageIntegration(t *testing.T) {
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Contains(reply.Text, text))
+}
+
+func TestTextMessageFailDueToStatusCode(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}))
+	defer ts.Close()
+	log := testhelp.MakeTestLog()
+	ctx := context.Background()
+
+	_, err := googlechat.TextMessage(ctx, log, ts.URL, "key", "bananas are ripe")
+
+	assert.ErrorContains(t, err, "TextMessage: status: 418 I'm a teapot")
 }
 
 func TestRedactURL(t *testing.T) {

--- a/testhelp/testlog.go
+++ b/testhelp/testlog.go
@@ -19,6 +19,7 @@ func MakeTestLog() *slog.Logger {
 	return slog.New(slog.NewTextHandler(
 		out,
 		&slog.HandlerOptions{
+			Level:       slog.LevelDebug,
 			ReplaceAttr: RemoveTime,
 		}))
 }


### PR DESCRIPTION
googlechat: retry on temporary failures and on timeouts

The API of googlechat.TextMessage is now a bit clumsy.
I plan another PR to simplify; on the other hand, this should be ready to be deployed.

Best reviewed commit-per-commit.

PCI-4096