### PR TITLE
ci: finally cache Go dependencies; try ratchet to pin GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           # By default, actions/checkout will persist the GITHUB_TOKEN, so that further
           # steps in the job can perform authenticated git commands (that is: WRITE to
@@ -25,13 +25,13 @@ jobs:
       # Installing Go must be done AFTER checking out the code, in order to have
       # caching working!
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.go-version }}
       - name: Install Task
         run: go install github.com/go-task/task/v3/cmd/task@${{ env.task-version }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # ratchet:golangci/golangci-lint-action@v9
         with:
           version: ${{ env.golangci-version }}
       - run: task build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,6 @@ jobs:
   all:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.go-version }}
-      - name: Install Task
-        run: go install github.com/go-task/task/v3/cmd/task@${{ env.task-version }}
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -28,6 +22,14 @@ jobs:
           # the repo). Following the Principle of least privilege, we disable this as long
           # as we don't need it.
           persist-credentials: false
+      # Installing Go must be done AFTER checking out the code, in order to have
+      # caching working!
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.go-version }}
+      - name: Install Task
+        run: go install github.com/go-task/task/v3/cmd/task@${{ env.task-version }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
1. ci: finally cache Go dependencies
It took me years of experiments to finally find the (obvious in retrospective) fix to the warning

    `Restore cache failed: Dependencies file is not found in /home/runner/work/cogito/cogito. Supported file pattern: go.mod`

This seems to have reduced the CI run from `1m30s` to `1m`.

2. try ratchet to pin GH Actions

Done with:

    ratchet pin .github/workflows/ci.yml

ratchet: https://github.com/sethvargo/ratchet

PCI-4096