### PR TITLE
More useful logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD
 
+## Changed
+
+- Update to github.com/Pix4D/go-kit@v0.4.0
+
 ### Breaking changes
 
 - Migrate package `googlechat` to https://github.com/Pix4D/go-kit.

--- a/cmd/cogito/main.go
+++ b/cmd/cogito/main.go
@@ -46,18 +46,7 @@ func mainErr(stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string)
 	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
 		return fmt.Errorf("%s. (valid: debug, info, warn, error)", err)
 	}
-	removeTime := func(groups []string, a slog.Attr) slog.Attr {
-		if a.Key == slog.TimeKey {
-			return slog.Attr{}
-		}
-		return a
-	}
-	log := slog.New(slog.NewTextHandler(
-		stderr,
-		&slog.HandlerOptions{
-			Level:       level,
-			ReplaceAttr: removeTime,
-		}))
+	log := makeProdLogger(stderr, level)
 	log.Info(cogito.BuildInfo())
 
 	switch cmd {
@@ -71,6 +60,57 @@ func mainErr(stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string)
 	default:
 		return fmt.Errorf("cli wiring error; please report")
 	}
+}
+
+// Strings constants for maximum performance.
+const (
+	logDBG     = "DBG"
+	logINF     = "INF"
+	logWRN     = "WRN"
+	logERR     = "ERR"
+	logUNKNOWN = "UNKNOWN"
+)
+
+func makeProdLogger(stderr io.Writer, level slog.Level) *slog.Logger {
+	replaceAttrs := func(groups []string, a slog.Attr) slog.Attr {
+		// Formatting time.
+		// One can change the timezone (default: local), but the format is fixed:
+		// RFC3339 (same as ISO 8601) with millisecond precision.
+		// To change the format, the Attr.Value must implement encoding.TextMarshaler.
+		// See: https://pkg.go.dev/log/slog#TextHandler.Handle
+		// if a.Key == slog.TimeKey {
+		// 	// This has no effect, see explanation above.
+		// 	a.Value = slog.TimeValue(a.Value.Time().Round(time.Second))
+		// 	return a
+		// }
+
+		// Format log levels to have all the same length.
+		if a.Key == slog.LevelKey {
+			level := a.Value.Any().(slog.Level)
+			switch level {
+			case slog.LevelDebug:
+				a.Value = slog.StringValue(logDBG)
+			case slog.LevelInfo:
+				a.Value = slog.StringValue(logINF)
+			case slog.LevelWarn:
+				a.Value = slog.StringValue(logWRN)
+			case slog.LevelError:
+				a.Value = slog.StringValue(logERR)
+			default:
+				a.Value = slog.StringValue(logUNKNOWN)
+			}
+			return a
+		}
+
+		return a
+	}
+
+	return slog.New(slog.NewTextHandler(
+		stderr,
+		&slog.HandlerOptions{
+			Level:       level,
+			ReplaceAttr: replaceAttrs,
+		}))
 }
 
 // peekLogLevel decodes 'input' as JSON and looks for key source.log_level. If 'input'

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -132,7 +132,7 @@ func TestRunPutSuccessIntegration(t *testing.T) {
 	assert.Assert(t, cmp.Contains(stderr.String(),
 		`level=INF msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
 	assert.Assert(t, cmp.Contains(stderr.String(),
-		`level=INF msg="state posted successfully to chat" name=cogito.put name=gChat state=error`))
+		`level=INF msg=posted-to-chat name=cogito.put name=gChat state=error`))
 }
 
 func TestRunPutGhAppSuccessIntegration(t *testing.T) {

--- a/cmd/cogito/main_test.go
+++ b/cmd/cogito/main_test.go
@@ -130,9 +130,9 @@ func TestRunPutSuccessIntegration(t *testing.T) {
 
 	assert.NilError(t, err, "\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
 	assert.Assert(t, cmp.Contains(stderr.String(),
-		`level=INFO msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
+		`level=INF msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
 	assert.Assert(t, cmp.Contains(stderr.String(),
-		`level=INFO msg="state posted successfully to chat" name=cogito.put name=gChat state=error`))
+		`level=INF msg="state posted successfully to chat" name=cogito.put name=gChat state=error`))
 }
 
 func TestRunPutGhAppSuccessIntegration(t *testing.T) {
@@ -172,7 +172,7 @@ func TestRunPutGhAppSuccessIntegration(t *testing.T) {
 
 	assert.NilError(t, err, "\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
 	assert.Assert(t, cmp.Contains(stderr.String(),
-		`level=INFO msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
+		`level=INF msg="commit status posted successfully" name=cogito.put name=ghCommitStatus state=error`))
 }
 
 func TestRunFailure(t *testing.T) {

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -54,9 +54,9 @@ func (sink GoogleChatSink) Send() error {
 		return fmt.Errorf("GoogleChatSink: %s", err)
 	}
 
+	spaceURL := reply.SpaceURL()
 	sink.Log.Info("state posted successfully to chat",
-		"state", state, "space", reply.Space.DisplayName,
-		"sender", reply.Sender.DisplayName, "text", text)
+		"state", state, "space-ID", reply.Space.Name, "space-URL", spaceURL, "text", text)
 	return nil
 }
 

--- a/cogito/gchatsink.go
+++ b/cogito/gchatsink.go
@@ -48,6 +48,7 @@ func (sink GoogleChatSink) Send() error {
 	}
 
 	threadKey := fmt.Sprintf("%s %s", sink.Request.Env.BuildPipelineName, sink.GitRef)
+	sink.Log.Debug("posting-to-chat", "text", text)
 	reply, err := googlechat.TextMessage(sink.Log, googlechat.DefaultRetry(sink.Log),
 		googlechat.DefaultTimeout, webHook, threadKey, text)
 	if err != nil {
@@ -55,8 +56,7 @@ func (sink GoogleChatSink) Send() error {
 	}
 
 	spaceURL := reply.SpaceURL()
-	sink.Log.Info("state posted successfully to chat",
-		"state", state, "space-ID", reply.Space.Name, "space-URL", spaceURL, "text", text)
+	sink.Log.Info("posted-to-chat", "state", state, "space", spaceURL)
 	return nil
 }
 

--- a/cogito/gchatsink_test.go
+++ b/cogito/gchatsink_test.go
@@ -129,7 +129,8 @@ func TestSinkGoogleChatSendBackendFailure(t *testing.T) {
 
 	err := sink.Send()
 
-	assert.ErrorContains(t, err, "GoogleChatSink: TextMessage: status: 418 I'm a teapot")
+	assert.ErrorContains(t, err,
+		"GoogleChatSink: TextMessage: retrySend: unretriable status code: 418 I'm a teapot")
 	ts.Close()
 }
 

--- a/cogito/get.go
+++ b/cogito/get.go
@@ -30,7 +30,7 @@ func Get(log *slog.Logger, input []byte, out io.Writer, args []string) error {
 	if err != nil {
 		return err
 	}
-	log.Debug("parsed get request",
+	log.Debug("parsed-get-request",
 		"source", request.Source,
 		"version", request.Version,
 		"environment", request.Env,

--- a/cogito/ghcommitsink.go
+++ b/cogito/ghcommitsink.go
@@ -7,20 +7,6 @@ import (
 	"time"
 
 	"github.com/Pix4D/go-kit/github"
-	"github.com/Pix4D/go-kit/retry"
-)
-
-const (
-	// retryUpTo is the total maximum duration of the retries.
-	retryUpTo = 15 * time.Minute
-
-	// retryFirstDelay is duration of the first backoff.
-	retryFirstDelay = 2 * time.Second
-
-	// retryBackoffLimit is the upper bound duration of a backoff.
-	// That is, with an exponential backoff and a retryFirstDelay = 2s, the sequence will be:
-	// 2s 4s 8s 16s 32s 60s ... 60s, until reaching a cumulative delay of retryUpTo.
-	retryBackoffLimit = 1 * time.Minute
 )
 
 // GitHubCommitStatusSink is an implementation of [Sinker] for the Cogito resource.
@@ -59,12 +45,7 @@ func (sink GitHubCommitStatusSink) Send() error {
 	target := &github.Target{
 		Client: httpClient,
 		Server: server,
-		Retry: retry.Retry{
-			FirstDelay:   retryFirstDelay,
-			BackoffLimit: retryBackoffLimit,
-			UpTo:         retryUpTo,
-			Log:          sink.Log,
-		},
+		Retry:  github.DefaultRetry(sink.Log),
 	}
 	commitStatus := github.NewCommitStatus(target, token,
 		sink.Request.Source.Owner, sink.Request.Source.Repo, context, sink.Log)

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -184,7 +185,31 @@ type Source struct {
 	Sinks              []string     `json:"sinks"`
 }
 
+// LogValue implements slog.LogValuer.
+// It returns a slog group, so that the fields of [Source] appear together.
+// It redacts sensitive fields.
+func (src Source) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("owner", src.Owner),
+		slog.String("repo", src.Repo),
+		slog.String("github_hostname", src.GhHostname),
+		slog.String("access_token", redact(src.AccessToken)),
+		slog.String("gchat_webhook", redact(src.GChatWebHook)),
+		slog.String("github_app.client_id", src.GitHubApp.ClientId),
+		slog.Int("github_app.installation_id", src.GitHubApp.InstallationId),
+		slog.String("github_app.private_key", redact(src.GitHubApp.PrivateKey)),
+		slog.String("log_level", src.LogLevel),
+		slog.String("context_prefix", src.ContextPrefix),
+		slog.Bool("omit_target_url", src.OmitTargetURL),
+		slog.Bool("chat_append_summary", src.ChatAppendSummary),
+		slog.String("chat_notify_on_states", fmt.Sprint(src.ChatNotifyOnStates)),
+		slog.String("sinks:", strings.Join(src.Sinks, ",")),
+	)
+}
+
 // String renders Source, redacting the sensitive fields.
+//
+// Deprecated: replaced by [Source.LogValue].
 func (src Source) String() string {
 	var bld strings.Builder
 
@@ -405,7 +430,24 @@ type PutParams struct {
 	Sinks             []string `json:"sinks"`
 }
 
+// LogValue implements slog.LogValuer.
+// It returns a slog group, so that the fields of [PutParams] appear together.
+// It redacts sensitive fields.
+func (params PutParams) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("state", string(params.State)),
+		slog.String("context", params.Context),
+		slog.String("chat_message", params.ChatMessage),
+		slog.String("chat_message_file", params.ChatMessageFile),
+		slog.Bool("chat_append_summary", params.ChatAppendSummary),
+		slog.String("gchat_webhook", redact(params.GChatWebHook)),
+		slog.String("sinks", strings.Join(params.Sinks, ",")),
+	)
+}
+
 // String renders PutParams, redacting the sensitive fields.
+//
+// Deprecated: replaced by [PutParams.LogValue].
 func (params PutParams) String() string {
 	var bld strings.Builder
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -316,8 +316,9 @@ sinks: []`
 		log.Info("log test", "source", source)
 		have := logBuf.String()
 
-		assert.Assert(t, cmp.Contains(have, "access_token:          ***REDACTED***"))
-		assert.Assert(t, cmp.Contains(have, "gchat_webhook:         ***REDACTED***"))
+		assert.Assert(t, cmp.Contains(have, "access_token=***REDACTED***"))
+		assert.Assert(t, cmp.Contains(have, "gchat_webhook=***REDACTED***"))
+		assert.Assert(t, cmp.Contains(have, "github_app.private_key=***REDACTED***"))
 		assert.Assert(t, !strings.Contains(have, "sensitive"))
 	})
 }
@@ -372,7 +373,7 @@ sinks:               []`
 		log.Info("log test", "params", params)
 		have := logBuf.String()
 
-		assert.Assert(t, cmp.Contains(have, "gchat_webhook:       ***REDACTED***"))
+		assert.Assert(t, cmp.Contains(have, "gchat_webhook=***REDACTED***"))
 		assert.Assert(t, !strings.Contains(have, "sensitive"))
 	})
 }

--- a/cogito/putter.go
+++ b/cogito/putter.go
@@ -40,7 +40,7 @@ func (putter *ProdPutter) LoadConfiguration(input []byte, args []string) error {
 		return err
 	}
 	putter.Request = request
-	putter.log.Debug("parsed put request",
+	putter.log.Debug("parsed-put-request",
 		"source", putter.Request.Source,
 		"params", putter.Request.Params,
 		"environment", putter.Request.Env,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	dario.cat/mergo v1.0.0
-	github.com/Pix4D/go-kit v0.3.0
+	github.com/Pix4D/go-kit v0.4.0
 	github.com/alexflint/go-arg v1.4.3
 	github.com/sasbury/mini v0.0.0-20181226232755-dc74af49394b
 	gotest.tools/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Pix4D/go-kit v0.3.0 h1:v6p1FrIS9/i0aipxJeFGY91xO/wWtXs+LJwmuZe+uvw=
-github.com/Pix4D/go-kit v0.3.0/go.mod h1:aGw8Ezrn6YJyQrT/6bwmtjJuvzKhuFJ0HsJ8GLzpOmk=
+github.com/Pix4D/go-kit v0.4.0 h1:C3x0pvlXKNtkfNtHhUD+ZOfSr7v1bXdi4fYY5hu0bdo=
+github.com/Pix4D/go-kit v0.4.0/go.mod h1:kNYgpPgIg39L4HeWfc69LRCjzdaEXZsYWtdgSHcUKJQ=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alexflint/go-arg v1.4.3 h1:9rwwEBpMXfKQKceuZfYcwuc/7YY7tWJbFsgG5cAU/uo=
@@ -16,8 +16,8 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/marco-m/rosina v0.2.0 h1:6Uut96T2j1eZuzlTMw1kOLeAmMBdAoHhy2Ym+3dttE8=
-github.com/marco-m/rosina v0.2.0/go.mod h1:U1TRxF7xCF1J8lhP/OABVz5UC9UmHZdIj+o8PSlXY+U=
+github.com/marco-m/rosina v0.3.0 h1:ROuUaRoEhTUj1bJsrzrVAOZDoiEIBFXWaZn0KIf8ntg=
+github.com/marco-m/rosina v0.3.0/go.mod h1:U1TRxF7xCF1J8lhP/OABVz5UC9UmHZdIj+o8PSlXY+U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sasbury/mini v0.0.0-20181226232755-dc74af49394b h1:E0nPZOFGK8IsGxpckEpr2+7AZ+0DUGbf+WNfnRugYFI=


### PR DESCRIPTION
Many quality of life improvements and adapt to (I think) changes to which fields the GoogleChat API actually fills.

User-visible changes in the logs:

- logs are now timestamped (see commit comment for rationale)
- logs are more readable with same length level string
- logs are cleaned up
- logs contain URL to GoogleChat space to which the message has been sent.

Better reviewed commit-per-commit


TODO
- [x] update go-kit tag once PR https://github.com/Pix4D/go-kit/pull/19 is merged

-PCI-4096